### PR TITLE
Create run engine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,3 +79,5 @@ directory = "coverage_html_report"
 
 [tool.pyright]
 include = ["src", "tests"]
+reportUntypedFunctionDecorator = true
+reportUntypedClassDecorator = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dev = [
 [tool.pytest.ini_options]
 testpaths = "tests"
 asyncio_mode = "auto"
-addopts = "--cov --cov-report=html"
+addopts = "--cov --cov-report=html -vv"
 
 [tool.coverage.run]
 branch = true

--- a/src/ibex_bluesky_core/demo_plan.py
+++ b/src/ibex_bluesky_core/demo_plan.py
@@ -5,13 +5,15 @@ from typing import Generator
 import bluesky.plan_stubs as bps
 from bluesky.callbacks import LiveTable
 from bluesky.preprocessors import run_decorator
-from bluesky.run_engine import RunEngine
 from bluesky.utils import Msg
 from ophyd_async.plan_stubs import ensure_connected
 
 from ibex_bluesky_core.devices import get_pv_prefix
 from ibex_bluesky_core.devices.block import Block
 from ibex_bluesky_core.devices.dae import Dae
+from ibex_bluesky_core.run_engine import get_run_engine
+
+__all__ = ["run_demo_plan", "demo_plan"]
 
 
 def run_demo_plan() -> None:
@@ -24,7 +26,7 @@ def run_demo_plan() -> None:
     >>> from ibex_bluesky_core.demo_plan import run_demo_plan
     >>> run_demo_plan()
     """
-    RE = RunEngine()
+    RE = get_run_engine()
     prefix = get_pv_prefix()
     block = Block(prefix, "mot", float)
     dae = Dae(prefix)

--- a/src/ibex_bluesky_core/run_engine.py
+++ b/src/ibex_bluesky_core/run_engine.py
@@ -2,30 +2,50 @@
 
 import asyncio
 from functools import cache
+from threading import Event
 
 from bluesky.run_engine import RunEngine
+from bluesky.utils import DuringTask
 
 __all__ = ["get_run_engine"]
+
+
+class _DuringTask(DuringTask):
+    def block(self, blocking_event: Event) -> None:
+        """On windows, event.wait() on the main thread is not interruptible by a CTRL-C.
+
+        Therefore, split the event.wait into many smaller event.waits, each with a 0.1 second
+        timeout. This allows:
+        - CTRL-C to be handled reasonably responsively for users
+        - returning as soon as possible after the event is set
+        - not busy-waiting
+        """
+        while not blocking_event.wait(0.1):
+            pass
 
 
 @cache
 def get_run_engine() -> RunEngine:
     """Acquire a RunEngine in a suitable configuration for ISIS experiments.
 
-    This function should always be used in preference to creating a bluesky
-    run engine manually.
+    This function should always be used in preference to creating a bluesky run engine manually.
 
-    This function is cached, meaning that the *same* run engine (using the same
-    underlying event loop) will be used if this function is called multiple
-    times. Creating multiple RunEngines is unlikely to be desired behaviour,
-    though we cannot prevent users from creating a RunEngine from bluesky directly.
+    This function is cached, meaning that the *same* run engine (using the same underlying event
+    loop) will be used if this function is called multiple times. Creating multiple RunEngines is
+    unlikely to be desired behaviour, though we cannot prevent users from creating a RunEngine from
+    bluesky directly.
 
     Generally should be used as:
     >>> RE = get_run_engine()
+    >>> plan: Generator[Msg, None, None] = ...
+    >>> RE(plan)  # Run a plan
+    >>> RE.subscribe(...)  # Subscribe to future documents emitted by the run engine
+    >>> RE.abort(reason="...")  # Control the state of the run engine
     """
     loop = asyncio.new_event_loop()
     RE = RunEngine(
         loop=loop,
+        during_task=_DuringTask(),
         call_returns_result=True,  # Will be default in a future bluesky version.
     )
     RE.record_interruptions = True

--- a/src/ibex_bluesky_core/run_engine.py
+++ b/src/ibex_bluesky_core/run_engine.py
@@ -35,12 +35,27 @@ def get_run_engine() -> RunEngine:
     unlikely to be desired behaviour, though we cannot prevent users from creating a RunEngine from
     bluesky directly.
 
-    Generally should be used as:
+    Basic usage:
+    - Get the IBEX run engine:
     >>> RE = get_run_engine()
-    >>> plan: Generator[Msg, None, None] = ...
-    >>> RE(plan)  # Run a plan
-    >>> RE.subscribe(...)  # Subscribe to future documents emitted by the run engine
-    >>> RE.abort(reason="...")  # Control the state of the run engine
+
+    - Run a plan:
+    >>> from bluesky.plans import count  # Or any other plan
+    >>> det = ...  # A "detector" object, for example a Block or Dae device.
+    >>> RE(count([det]))
+
+    - Control the state of the run engine:
+    >>> RE.abort(reason="...")  # Stop a plan, do cleanup, and mark as failed (e.g. bad data).
+    >>> RE.stop()  # Stop a plan, do cleanup, mark as success"(e.g. scan has moved past peak).
+    >>> RE.halt()  # Stop a plan, don't do any cleanup, just abort with no further action.
+    >>> RE.resume()  # Resume running a previously-paused plan.
+
+    - Subscribe to data emitted by this run engine:
+    >>> RE.subscribe(lambda name, document: ...)
+
+    For full documentation about the run engine, see:
+    - https://nsls-ii.github.io/bluesky/tutorial.html#the-runengine
+    - https://nsls-ii.github.io/bluesky/run_engine_api.html
     """
     loop = asyncio.new_event_loop()
     RE = RunEngine(

--- a/src/ibex_bluesky_core/run_engine.py
+++ b/src/ibex_bluesky_core/run_engine.py
@@ -1,0 +1,33 @@
+"""Utilities for the bluesky run engine, configured for IBEX."""
+
+import asyncio
+from functools import cache
+
+from bluesky.run_engine import RunEngine
+
+__all__ = ["get_run_engine"]
+
+
+@cache
+def get_run_engine() -> RunEngine:
+    """Acquire a RunEngine in a suitable configuration for ISIS experiments.
+
+    This function should always be used in preference to creating a bluesky
+    run engine manually.
+
+    This function is cached, meaning that the *same* run engine (using the same
+    underlying event loop) will be used if this function is called multiple
+    times. Creating multiple RunEngines is unlikely to be desired behaviour,
+    though we cannot prevent users from creating a RunEngine from bluesky directly.
+
+    Generally should be used as:
+    >>> RE = get_run_engine()
+    """
+    loop = asyncio.new_event_loop()
+    RE = RunEngine(
+        loop=loop,
+        call_returns_result=True,  # Will be default in a future bluesky version.
+    )
+    RE.record_interruptions = True
+
+    return RE

--- a/src/ibex_bluesky_core/run_engine.py
+++ b/src/ibex_bluesky_core/run_engine.py
@@ -24,7 +24,7 @@ class _DuringTask(DuringTask):
             pass
 
 
-@cache
+@cache  # functools.cache ensures we only ever create a single instance of the RunEngine
 def get_run_engine() -> RunEngine:
     """Acquire a RunEngine in a suitable configuration for ISIS experiments.
 

--- a/tests/test_run_engine.py
+++ b/tests/test_run_engine.py
@@ -1,0 +1,72 @@
+from typing import Any, Generator
+
+import bluesky.plan_stubs as bps
+import pytest
+from bluesky.run_engine import RunEngineResult
+from bluesky.utils import Msg, RequestAbort, RunEngineInterrupted
+from ibex_bluesky_core.run_engine import get_run_engine
+
+
+@pytest.fixture
+def RE():
+    get_run_engine.cache_clear()
+    return get_run_engine()
+
+
+def test_run_engine_is_singleton():
+    re1 = get_run_engine()
+    re2 = get_run_engine()
+
+    assert re1 is re2
+
+
+def test_run_engine_can_be_used_for_simple_plan(RE):
+    def plan() -> Generator[Msg, None, Any]:
+        yield from bps.null()
+        return "plan_result"
+
+    assert RE(plan()) == RunEngineResult((), "plan_result", "success", False, "", None)
+
+
+def test_run_engine_reports_aborted_plan(RE):
+    def pausing_plan() -> Generator[Msg, None, None]:
+        yield from bps.pause()
+
+    with pytest.raises(RunEngineInterrupted):
+        RE(pausing_plan())
+
+    result: RunEngineResult = RE.abort("abort reason")
+
+    assert result.run_start_uids == ()
+    assert result.plan_result == RE.NO_PLAN_RETURN
+    assert result.exit_status == "abort"
+    assert result.interrupted
+    assert isinstance(result.exception, RequestAbort)
+    assert result.reason == "abort reason"
+
+
+def test_run_engine_reports_plan_which_pauses_resumes_and_then_returns(RE):
+    def pausing_plan() -> Generator[Msg, None, str]:
+        yield from bps.pause()
+        return "plan result"
+
+    with pytest.raises(RunEngineInterrupted):
+        RE(pausing_plan())
+
+    result: RunEngineResult = RE.resume()
+
+    assert result == RunEngineResult((), "plan result", "success", False, "", None)
+
+
+def test_run_engine_can_emit_documents_to_custom_subscriber(RE):
+    def basic_plan() -> Generator[Msg, None, None]:
+        yield from bps.open_run()
+        yield from bps.close_run()
+
+    documents = []
+    RE.subscribe(lambda typ, _doc: documents.append(typ))
+
+    RE(basic_plan())
+
+    # Expected basic series of document types for a start run/stop run sequence.
+    assert documents == ["start", "descriptor", "stop"]

--- a/tests/test_run_engine.py
+++ b/tests/test_run_engine.py
@@ -3,7 +3,7 @@ from typing import Any, Generator
 import bluesky.plan_stubs as bps
 import pytest
 from bluesky.run_engine import RunEngineResult
-from bluesky.utils import Msg, RequestAbort, RunEngineInterrupted
+from bluesky.utils import Msg, RequestAbort, RequestStop, RunEngineInterrupted
 from ibex_bluesky_core.run_engine import get_run_engine
 
 
@@ -70,3 +70,58 @@ def test_run_engine_can_emit_documents_to_custom_subscriber(RE):
 
     # Expected basic series of document types for a start run/stop run sequence.
     assert documents == ["start", "descriptor", "stop"]
+
+
+def test_run_engine_emits_documents_for_interruptions(RE):
+    def pausing_plan() -> Generator[Msg, None, None]:
+        yield from bps.open_run(md={"reason": "run one start"})
+        yield from bps.pause()
+        yield from bps.close_run(reason="run one end")
+        yield from bps.open_run(md={"reason": "run two start"})
+        yield from bps.pause()
+        yield from bps.close_run(reason="run two end")
+
+    doc_types = []
+    docs = []
+
+    def sub(typ, doc):
+        doc_types.append(typ)
+        docs.append({typ: doc})
+
+    RE.subscribe(sub)
+
+    with pytest.raises(RunEngineInterrupted):
+        RE(pausing_plan())
+
+    with pytest.raises(RunEngineInterrupted):
+        RE.resume()
+
+    result: RunEngineResult = RE.stop()
+
+    assert doc_types == [
+        "start",  # Open run 1
+        "descriptor",  # Open run descriptor
+        "event",  # First pause
+        "event",  # Resume
+        "stop",  # Close run 1
+        "start",  # Open run 2
+        "descriptor",  # Open run descriptor
+        "event",  # Second pause
+        "stop",  # Close run 2
+    ]
+
+    assert docs[0]["start"]["reason"] == "run one start"
+    assert docs[2]["event"]["data"] == {"interruption": "pause"}
+    assert docs[3]["event"]["data"] == {"interruption": "resume"}
+    assert docs[4]["stop"]["reason"] == "run one end"
+
+    assert docs[5]["start"]["reason"] == "run two start"
+    assert docs[7]["event"]["data"] == {"interruption": "pause"}
+    assert docs[8]["stop"]["reason"] == ""  # Stopped by run engine, *not* our close_run
+
+    assert len(result.run_start_uids) == 2  # Both runs started
+    assert result.plan_result == RE.NO_PLAN_RETURN
+    assert result.exit_status == "success"
+    assert result.interrupted
+    assert result.exception == RequestStop
+    assert result.reason == ""


### PR DESCRIPTION
Create a run engine, and add basic tests for run engine functionality.

https://github.com/ISISComputingGroup/ibex_bluesky_core/issues/2

To review:
- Check demo plan works
- Check tests & linting pass (this will soon be done by CI, but as CI is not merged yet, it needs to be checked manually)
- Check as a developer you agree with the initial basic set of tests for bluesky run engine functionality (the goal is not to exhaustively test it, but to check we've configured it in a sane way)
- Check as a developer basic interactive run engine functionality works - e.g. run a plan, interrupt it, add a custom callback, etc.

Notes:
- The custom `_DuringTask` has been pushed upstream (https://github.com/bluesky/bluesky/pull/1770); if & when that PR gets merged & released we can remove our version