### PR TITLE
Added document logging & unit tests

### DIFF
--- a/.github/workflows/Lint-and-test.yml
+++ b/.github/workflows/Lint-and-test.yml
@@ -4,7 +4,7 @@ jobs:
   call-linter-workflow:
     uses: ISISComputingGroup/reusable-workflows/.github/workflows/linters.yml@install_proj_dependancies_in_workflow
     with:
-      compare-branch: origin/install_proj_dependancies_in_workflow
+      compare-branch: origin/main
       python-ver: '3.11'
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/Lint-and-test.yml
+++ b/.github/workflows/Lint-and-test.yml
@@ -2,7 +2,7 @@ name: Lint-and-test
 on: [pull_request, workflow_call]
 jobs:
   call-linter-workflow:
-    uses: ISISComputingGroup/reusable-workflows/.github/workflows/linters.yml@install_proj_dependancies_in_workflow
+    uses: ISISComputingGroup/reusable-workflows/.github/workflows/linters.yml@main
     with:
       compare-branch: origin/main
       python-ver: '3.11'

--- a/.github/workflows/Lint-and-test.yml
+++ b/.github/workflows/Lint-and-test.yml
@@ -2,9 +2,9 @@ name: Lint-and-test
 on: [pull_request, workflow_call]
 jobs:
   call-linter-workflow:
-    uses: ISISComputingGroup/reusable-workflows/.github/workflows/linters.yml@main
+    uses: ISISComputingGroup/reusable-workflows/.github/workflows/linters.yml@install_proj_dependancies_in_workflow
     with:
-      compare-branch: origin/main
+      compare-branch: origin/install_proj_dependancies_in_workflow
       python-ver: '3.11'
   tests:
     runs-on: ubuntu-latest

--- a/doc/docs_logging_callback.md
+++ b/doc/docs_logging_callback.md
@@ -1,0 +1,5 @@
+# Document Logging Callback
+
+The document logger is a callback that the BlueSky RunEngine subscribes to unconditionally. After receiving each document it will write documents in the same file with other documents sharing the same start document (In the same run). These logs are stored under `C://instrument/var/logs/bluesky/raw_documents` and are handled by the log rotation.
+
+Each document is stored in a JSON format so can be both machine and human readable. It is in the format `{"type": name, "document": document}` whereby `name` is the type of the document, e.g start, stop, event, descriptor and the `document` is the document from BlueSky in JSON format. As these files are produced per BlueSky run, these will be useful for debugging.

--- a/doc/docs_logging_callback.md
+++ b/doc/docs_logging_callback.md
@@ -1,5 +1,5 @@
 # Document Logging Callback
 
-The document logger is a callback that the BlueSky RunEngine subscribes to unconditionally. After receiving each document it will write documents in the same file with other documents sharing the same start document (In the same run). These logs are stored under `C://instrument/var/logs/bluesky/raw_documents` and are handled by the log rotation.
+The document logger is a callback that the BlueSky RunEngine subscribes to unconditionally. After receiving each document, if they share the same start document (in the same run) then it will write them to the same file. These logs are stored under `C:/instrument/var/logs/bluesky/raw_documents` and are handled by the log rotation.
 
-Each document is stored in a JSON format so can be both machine and human readable. It is in the format `{"type": name, "document": document}` whereby `name` is the type of the document, e.g start, stop, event, descriptor and the `document` is the document from BlueSky in JSON format. As these files are produced per BlueSky run, these will be useful for debugging.
+Each document is stored in a JSON format so can be both machine and human readable. It is in the format `{"type": name, "document": document}` whereby `name` is the type of the document, e.g start, stop, event, descriptor and the `document` is the [document from BlueSky in JSON format](https://blueskyproject.io/bluesky/main/documents.html). As these files are produced per BlueSky run, these will be useful for debugging.

--- a/src/ibex_bluesky_core/callbacks/__init__.py
+++ b/src/ibex_bluesky_core/callbacks/__init__.py
@@ -1,0 +1,1 @@
+"""For callbacks that relate to the BlueSky run engine."""

--- a/src/ibex_bluesky_core/callbacks/document_logger.py
+++ b/src/ibex_bluesky_core/callbacks/document_logger.py
@@ -8,33 +8,28 @@ log_location = Path(os.path.join("C:\\", "instrument", "var", "logs", "bluesky",
 
 
 class DocLoggingCallback:
-    """
-    Logs all documents under log_location, with the file name of their UID (.log).
-    """
+    """Logs all documents under log_location, with the file name of their UID (.log)."""
 
     def __init__(self) -> None:
-        """
-        Initialises current_start_document and filename.
-        """
-
+        """Initialise current_start_document and filename."""
         self.current_start_document = None
         self.filename = None
 
     def __call__(self, name: str, document: dict) -> int:
-        """
-        Is called when a new document needs to be processed. Writes document to a file.
+        """Is called when a new document needs to be processed. Writes document to a file.
 
         Args:
             name: The type of the document e.g start, event, stop
             document: The contents of the docuement as a dictionary
+        
         """
-
         if name == "start":
             log_location.mkdir(parents=True, exist_ok=True)
 
             self.current_start_document = document["uid"]
-            self.filename: str = os.path.join(log_location, f"{self.current_start_document}.log")
+            self.filename = os.path.join(log_location, f"{self.current_start_document}.log")
 
+        assert self.filename is not None, "Could not create filename."
         assert self.current_start_document is not None, "Saw a non-start document before a start."
 
         to_write = {"type": name, "document": document}

--- a/src/ibex_bluesky_core/callbacks/document_logger.py
+++ b/src/ibex_bluesky_core/callbacks/document_logger.py
@@ -21,7 +21,6 @@ class DocLoggingCallback:
         Args:
             name: The type of the document e.g start, event, stop
             document: The contents of the docuement as a dictionary
-        
         """
         if name == "start":
             log_location.mkdir(parents=True, exist_ok=True)

--- a/src/ibex_bluesky_core/callbacks/document_logger.py
+++ b/src/ibex_bluesky_core/callbacks/document_logger.py
@@ -21,6 +21,7 @@ class DocLoggingCallback:
         Args:
             name: The type of the document e.g start, event, stop
             document: The contents of the docuement as a dictionary
+
         """
         if name == "start":
             log_location.mkdir(parents=True, exist_ok=True)

--- a/src/ibex_bluesky_core/callbacks/document_logger.py
+++ b/src/ibex_bluesky_core/callbacks/document_logger.py
@@ -1,0 +1,34 @@
+"""Logs all documents that the BlueSky run engine creates via a callback"""
+
+import os, json
+from pathlib import Path
+
+DEFAULT_LOG_LOCATION = Path(os.path.join("C:\\","instrument","var","logs","bluesky","raw_documents"))
+
+
+class DocLoggingCallback():
+
+    def __init__(self) -> None:
+        self.current_start_document = None
+        self.filename = None
+
+    def __call__(self, name, document):
+
+        if name == "start":
+
+            DEFAULT_LOG_LOCATION.mkdir(parents=True, exist_ok=True)
+
+            self.current_start_document = document["uid"]
+            self.filename = os.path.join(DEFAULT_LOG_LOCATION, f"{self.current_start_document}.log")
+
+        assert self.current_start_document is not None, "Saw a non-start document before a start."
+        
+        to_write = {
+            "type": name,
+            "document": document
+        }
+
+        with open(self.filename, 'a') as outfile:
+            outfile.write(f"{json.dumps(to_write)}\n")
+
+        return 0

--- a/src/ibex_bluesky_core/callbacks/document_logger.py
+++ b/src/ibex_bluesky_core/callbacks/document_logger.py
@@ -1,34 +1,45 @@
-"""Logs all documents that the BlueSky run engine creates via a callback"""
+"""Logs all documents that the BlueSky run engine creates via a callback."""
 
-import os, json
+import json
+import os
 from pathlib import Path
 
-DEFAULT_LOG_LOCATION = Path(os.path.join("C:\\","instrument","var","logs","bluesky","raw_documents"))
+log_location = Path(os.path.join("C:\\", "instrument", "var", "logs", "bluesky", "raw_documents"))
 
 
-class DocLoggingCallback():
+class DocLoggingCallback:
+    """
+    Logs all documents under log_location, with the file name of their UID (.log).
+    """
 
     def __init__(self) -> None:
+        """
+        Initialises current_start_document and filename.
+        """
+
         self.current_start_document = None
         self.filename = None
 
-    def __call__(self, name, document):
+    def __call__(self, name: str, document: dict) -> int:
+        """
+        Is called when a new document needs to be processed. Writes document to a file.
+
+        Args:
+            name: The type of the document e.g start, event, stop
+            document: The contents of the docuement as a dictionary
+        """
 
         if name == "start":
-
-            DEFAULT_LOG_LOCATION.mkdir(parents=True, exist_ok=True)
+            log_location.mkdir(parents=True, exist_ok=True)
 
             self.current_start_document = document["uid"]
-            self.filename = os.path.join(DEFAULT_LOG_LOCATION, f"{self.current_start_document}.log")
+            self.filename: str = os.path.join(log_location, f"{self.current_start_document}.log")
 
         assert self.current_start_document is not None, "Saw a non-start document before a start."
-        
-        to_write = {
-            "type": name,
-            "document": document
-        }
 
-        with open(self.filename, 'a') as outfile:
+        to_write = {"type": name, "document": document}
+
+        with open(self.filename, "a") as outfile:
             outfile.write(f"{json.dumps(to_write)}\n")
 
         return 0

--- a/src/ibex_bluesky_core/callbacks/document_logger.py
+++ b/src/ibex_bluesky_core/callbacks/document_logger.py
@@ -1,10 +1,9 @@
 """Logs all documents that the BlueSky run engine creates via a callback."""
 
 import json
-import os
 from pathlib import Path
 
-log_location = Path(os.path.join("C:\\", "instrument", "var", "logs", "bluesky", "raw_documents"))
+log_location = Path("C:\\") / "instrument" / "var" / "logs" / "bluesky" / "raw_documents"
 
 
 class DocLoggingCallback:
@@ -15,7 +14,7 @@ class DocLoggingCallback:
         self.current_start_document = None
         self.filename = None
 
-    def __call__(self, name: str, document: dict) -> int:
+    def __call__(self, name: str, document: dict) -> None:
         """Is called when a new document needs to be processed. Writes document to a file.
 
         Args:
@@ -27,7 +26,7 @@ class DocLoggingCallback:
             log_location.mkdir(parents=True, exist_ok=True)
 
             self.current_start_document = document["uid"]
-            self.filename = os.path.join(log_location, f"{self.current_start_document}.log")
+            self.filename = log_location / f"{self.current_start_document}.log"
 
         assert self.filename is not None, "Could not create filename."
         assert self.current_start_document is not None, "Saw a non-start document before a start."
@@ -36,5 +35,3 @@ class DocLoggingCallback:
 
         with open(self.filename, "a") as outfile:
             outfile.write(f"{json.dumps(to_write)}\n")
-
-        return 0

--- a/src/ibex_bluesky_core/run_engine.py
+++ b/src/ibex_bluesky_core/run_engine.py
@@ -6,6 +6,7 @@ from threading import Event
 
 from bluesky.run_engine import RunEngine
 from bluesky.utils import DuringTask
+
 from ibex_bluesky_core.callbacks.document_logger import DocLoggingCallback
 
 __all__ = ["get_run_engine"]
@@ -67,6 +68,6 @@ def get_run_engine() -> RunEngine:
     RE.record_interruptions = True
 
     log_callback = DocLoggingCallback()
-    RE.subscribe(log_callback) # Uses ID = 0 for DocLoggingCallback
+    RE.subscribe(log_callback)  # Uses ID = 0 for DocLoggingCallback
 
     return RE

--- a/src/ibex_bluesky_core/run_engine.py
+++ b/src/ibex_bluesky_core/run_engine.py
@@ -6,6 +6,7 @@ from threading import Event
 
 from bluesky.run_engine import RunEngine
 from bluesky.utils import DuringTask
+from ibex_bluesky_core.callbacks.document_logger import DocLoggingCallback
 
 __all__ = ["get_run_engine"]
 
@@ -64,5 +65,8 @@ def get_run_engine() -> RunEngine:
         call_returns_result=True,  # Will be default in a future bluesky version.
     )
     RE.record_interruptions = True
+
+    log_callback = DocLoggingCallback()
+    RE.subscribe(log_callback) # Uses ID = 0 for DocLoggingCallback
 
     return RE

--- a/src/ibex_bluesky_core/run_engine.py
+++ b/src/ibex_bluesky_core/run_engine.py
@@ -68,6 +68,6 @@ def get_run_engine() -> RunEngine:
     RE.record_interruptions = True
 
     log_callback = DocLoggingCallback()
-    RE.subscribe(log_callback)  # Uses ID = 0 for DocLoggingCallback
+    RE.subscribe(log_callback)
 
     return RE

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+from bluesky.run_engine import RunEngine
+from ibex_bluesky_core.run_engine import get_run_engine
+
+
+@pytest.fixture
+def RE() -> RunEngine:
+    get_run_engine.cache_clear()
+    return get_run_engine()

--- a/tests/test_document_logging_callback.py
+++ b/tests/test_document_logging_callback.py
@@ -10,7 +10,6 @@ from bluesky.utils import Msg
 
 def test_run_engine_logs_all_documents(RE):
     m = mock_open()
-    filepath: str
     log_location = Path("C:\\") / "instrument" / "var" / "logs" / "bluesky" / "raw_documents"
 
     def basic_plan() -> Generator[Msg, None, None]:

--- a/tests/test_document_logging_callback.py
+++ b/tests/test_document_logging_callback.py
@@ -1,0 +1,33 @@
+import json
+from pathlib import Path
+from typing import Generator
+from unittest.mock import mock_open, patch
+
+import bluesky.plan_stubs as bps
+from bluesky.run_engine import RunEngineResult
+from bluesky.utils import Msg
+
+
+def test_run_engine_logs_all_documents(RE):
+    m = mock_open()
+    filepath: str
+    log_location = Path("C:\\") / "instrument" / "var" / "logs" / "bluesky" / "raw_documents"
+
+    def basic_plan() -> Generator[Msg, None, None]:
+        yield from bps.open_run()
+        yield from bps.close_run()
+
+    with patch("ibex_bluesky_core.callbacks.document_logger.open", m):
+        result: RunEngineResult = RE(basic_plan())
+        filepath = log_location / f"{result.run_start_uids[0]}.log"
+
+    for i in range(0, 3):
+        assert m.call_args_list[i].args == (filepath, "a")
+        # Checks that the file is opened 3 times, for open, descriptor then stop
+
+    handle = m()
+    document = json.loads(handle.write.mock_calls[-1].args[0])
+
+    assert document["document"]["exit_status"] == "success"
+    # In the stop document to be written, check that the run is successful with no interruptions
+    assert document["document"]["num_events"]["interruptions"] == 0

--- a/tests/test_run_engine.py
+++ b/tests/test_run_engine.py
@@ -1,21 +1,12 @@
-import json
-import os
 import threading
-from pathlib import Path
 from typing import Any, Generator
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock
 
 import bluesky.plan_stubs as bps
 import pytest
-from bluesky.run_engine import RunEngine, RunEngineResult
+from bluesky.run_engine import RunEngineResult
 from bluesky.utils import Msg, RequestAbort, RequestStop, RunEngineInterrupted
 from ibex_bluesky_core.run_engine import _DuringTask, get_run_engine
-
-
-@pytest.fixture
-def RE() -> RunEngine:
-    get_run_engine.cache_clear()
-    return get_run_engine()
 
 
 def test_run_engine_is_singleton():
@@ -142,30 +133,3 @@ def test_during_task_does_wait_with_small_timeout():
 
     event.wait.assert_called_with(0.1)
     assert event.wait.call_count == 2
-
-
-def test_run_engine_logs_all_documents(RE):
-    m = mock_open()
-    filepath: str
-    log_location = Path(
-        os.path.join("C:\\", "instrument", "var", "logs", "bluesky", "raw_documents")
-    )
-
-    def basic_plan() -> Generator[Msg, None, None]:
-        yield from bps.open_run()
-        yield from bps.close_run()
-
-    with patch("ibex_bluesky_core.callbacks.document_logger.open", m):
-        result: RunEngineResult = RE(basic_plan())
-        filepath = os.path.join(log_location, f"{result.run_start_uids[0]}.log")
-
-    for i in range(0, 3):
-        assert m.call_args_list[i].args == (filepath, "a")
-        # Checks that the file is opened 3 times, for open, descriptor then stop
-
-    handle = m()
-    document = json.loads(handle.write.mock_calls[-1].args[0])
-
-    assert document["document"]["exit_status"] == "success"
-    # In the stop document to be written, check that the run is successful with no interruptions
-    assert document["document"]["num_events"]["interruptions"] == 0

--- a/tests/test_run_engine.py
+++ b/tests/test_run_engine.py
@@ -1,12 +1,15 @@
+import json
+from pathlib import Path
 import threading
 from typing import Any, Generator
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, mock_open, patch
 
 import bluesky.plan_stubs as bps
 import pytest
 from bluesky.run_engine import RunEngine, RunEngineResult
 from bluesky.utils import Msg, RequestAbort, RequestStop, RunEngineInterrupted
 from ibex_bluesky_core.run_engine import _DuringTask, get_run_engine
+import os
 
 
 @pytest.fixture
@@ -139,3 +142,26 @@ def test_during_task_does_wait_with_small_timeout():
 
     event.wait.assert_called_with(0.1)
     assert event.wait.call_count == 2
+
+def test_run_engine_logs_all_documents(RE):
+
+    m = mock_open()
+    filepath: str
+    DEFAULT_LOG_LOCATION = Path(os.path.join("C:\\","instrument","var","logs","bluesky","raw_documents"))
+
+    def basic_plan() -> Generator[Msg, None, None]:
+        yield from bps.open_run()
+        yield from bps.close_run()
+
+    with patch('ibex_bluesky_core.callbacks.document_logger.open', m):
+        result: RunEngineResult = RE(basic_plan())
+        filepath = os.path.join(DEFAULT_LOG_LOCATION, f"{result.run_start_uids[0]}.log")
+    
+    for i in range (0,3):
+        assert m.call_args_list[i].args == (filepath, 'a') # Checks that the file is opened 3 times, for open, descriptor then stop
+
+    handle = m()
+    document = json.loads(handle.write.mock_calls[-1].args[0])
+    
+    assert document['document']['exit_status'] == "success" # In the stop document to be written, check that the run is successful with no interruptions
+    assert document['document']['num_events']['interruptions'] == 0


### PR DESCRIPTION
- Creates a new callback function that the BlueSky run engine subscribes to which records every document in a log file under "C:\\","instrument","var","logs","bluesky","raw_documents".
- Added a unit test that checks that the file to be written to is opened 3 times, for open, descriptor then stop. Also in the stop document to be written, checks that the run is successful with no interruptions.
- Callback returns an ID of 0 if it is ever needed to unsubscribe

[Ticket6](https://github.com/ISISComputingGroup/ibex_bluesky_core/issues/6#issue-2437829032)