### PR TITLE
Fixes issues found with linear fitting guess function

### DIFF
--- a/doc/fitting/fitting.md
+++ b/doc/fitting/fitting.md
@@ -176,7 +176,7 @@ from ibex_bluesky_core.callbacks.fitting.fitting_utils import Linear
 # This Guessing. function isn't very good because it's return values don't change on the data already collected in the Bluesky run
 # It always guesses that the linear function is y = x
 
-def different_guess(x: float, m: float, c: float) -> float:
+def different_guess(x: float, c1: float, c0: float) -> float:
     
     init_guess = {
         "c1": lmfit.Parameter("c1", 1), # gradient

--- a/doc/fitting/fitting.md
+++ b/doc/fitting/fitting.md
@@ -111,9 +111,9 @@ See the following example on how to define these.
 
 import lmfit
 
-def model(x: float, m: float, c: float) -> float:
+def model(x: float, c1: float, c0: float) -> float:
     
-    return m * x + c # y = mx + c
+    return c1 * x + c0 # y = mx + c
 
 def guess(x: npt.NDArray[np.float64], y: npt.NDArray[np.float64]) -> dict[str, lmfit.Parameter]:
 
@@ -125,12 +125,12 @@ def guess(x: npt.NDArray[np.float64], y: npt.NDArray[np.float64]) -> dict[str, l
     numerator = sum(x * y) - sum(x) * sum(y)
     denominator = sum(x**2) - sum(x) ** 2
 
-    m = numerator / denominator
-    c = (sum(y) - m * sum(x)) / len(x)
+    c1 = numerator / denominator
+    c0 = (sum(y) - c1 * sum(x)) / len(x)
 
     init_guess = {
-        "m": lmfit.Parameter("m", m), # gradient
-        "c": lmfit.Parameter("c", c), # y - intercept
+        "c1": lmfit.Parameter("c1", c1), # gradient
+        "c0": lmfit.Parameter("c0", c0), # y - intercept
     }
 
     return init_guess
@@ -155,9 +155,9 @@ This means that aslong as the parameters returned from the guess function match 
 import lmfit
 from ibex_bluesky_core.callbacks.fitting.fitting_utils import Linear
 
-def different_model(x: float, m: float, c: float) -> float:
+def different_model(x: float, c1: float, c0: float) -> float:
     
-    return m * x + c ** 2 # y = mx + (c ** 2)
+    return c1 * x + c0 ** 2 # y = mx + (c ** 2)
 
 
 fit_method = FitMethod(different_model, Linear.guess())
@@ -179,8 +179,8 @@ from ibex_bluesky_core.callbacks.fitting.fitting_utils import Linear
 def different_guess(x: float, m: float, c: float) -> float:
     
     init_guess = {
-        "m": lmfit.Parameter("m", 1), # gradient
-        "c": lmfit.Parameter("c", 0), # y - intercept
+        "c1": lmfit.Parameter("c1", 1), # gradient
+        "c0": lmfit.Parameter("c0", 0), # y - intercept
     }
 
     return init_guess

--- a/doc/fitting/standard_fits.md
+++ b/doc/fitting/standard_fits.md
@@ -2,20 +2,20 @@
 
 ## Linear
 
-- `m` - Gradient
-- `c` - (y) Intercept
+- `c1` - Gradient
+- `c0` - (y) Intercept
 
 ```{math}
-y = mx + c
+y = c_1x + c_0
 ```
 
 ## Polynomial
 
-- `a` ... `d` - Polynomial coefficients
+- `cn` ... `c0` - Polynomial coefficients
 
 For a polynomial degree `n`:
 ```{math}
-y = ax^n + bx^n-1 + ... + cx^1 + d 
+y = c_{n}x^n + c_{n-1}x^n-1 + ... + c_1 * x^1 + c_0 
 ```
 
 ## Gaussian

--- a/src/ibex_bluesky_core/callbacks/fitting/fitting_utils.py
+++ b/src/ibex_bluesky_core/callbacks/fitting/fitting_utils.py
@@ -179,8 +179,8 @@ class Linear(Fit):
     def model(cls, *args: int) -> lmfit.Model:
         """Linear Model."""
 
-        def model(x: npt.NDArray[np.float64], m: float, c: float) -> npt.NDArray[np.float64]:
-            return m * x + c
+        def model(x: npt.NDArray[np.float64], c1: float, c0: float) -> npt.NDArray[np.float64]:
+            return c1 * x + c0
 
         return lmfit.Model(model)
 
@@ -189,25 +189,8 @@ class Linear(Fit):
         cls, *args: int
     ) -> Callable[[npt.NDArray[np.float64], npt.NDArray[np.float64]], dict[str, lmfit.Parameter]]:
         """Linear Guessing."""
-
-        def guess(
-            x: npt.NDArray[np.float64], y: npt.NDArray[np.float64]
-        ) -> dict[str, lmfit.Parameter]:
-            # Linear Regression
-            numerator = sum(x * y) - sum(x) * sum(y)
-            denominator = sum(x**2) - sum(x) ** 2
-
-            m = numerator / denominator
-            c = (sum(y) - m * sum(x)) / len(x)
-
-            init_guess = {
-                "m": lmfit.Parameter("m", m),
-                "c": lmfit.Parameter("c", c),
-            }
-
-            return init_guess
-
-        return guess
+        return Polynomial.guess(1)
+        # Uses polynomial guessing with a degree of 1
 
 
 class Polynomial(Fit):

--- a/tests/callbacks/fitting/test_fitting_methods.py
+++ b/tests/callbacks/fitting/test_fitting_methods.py
@@ -248,6 +248,13 @@ class TestLinear:
 
             assert pytest.approx(outp["c0"]) == 0.0
 
+        def test_zero_gradient_guess(self):
+            x = np.array([-1.0, 0.0, 1.0])
+            y = np.array([0.0, 0.0, 0.0])
+            outp = Linear.guess()(x, y)
+
+            assert pytest.approx(outp["c1"]) == 0.0
+
 
 class TestPolynomial:
     class TestPolynomialModel:

--- a/tests/callbacks/fitting/test_fitting_methods.py
+++ b/tests/callbacks/fitting/test_fitting_methods.py
@@ -219,7 +219,7 @@ class TestLinear:
             grad = 3
             y_intercept = 2
 
-            outp = Linear.model().func(x, m=grad, c=y_intercept)
+            outp = Linear.model().func(x, c1=grad, c0=y_intercept)
 
             # Check for constant gradient of grad
             outp_m = np.diff(outp)
@@ -234,19 +234,19 @@ class TestLinear:
             y = np.array([-1.0, 0.0, 1.0])
             outp = Linear.guess()(x, y)
 
-            assert pytest.approx(outp["m"]) == 1.0
+            assert pytest.approx(outp["c1"]) == 1.0
 
             y = np.array([-2.0, 0.0, 2.0])
             outp1 = Linear.guess()(x, y)
             # check with a graph with steeper gradient
-            assert outp["m"] < outp1["m"]
+            assert outp["c1"] < outp1["c1"]
 
         def test_y_intercept_guess(self):
             x = np.array([-1.0, 0.0, 1.0])
             y = np.array([-1.0, 0.0, 1.0])
             outp = Linear.guess()(x, y)
 
-            assert pytest.approx(outp["c"]) == 0.0
+            assert pytest.approx(outp["c0"]) == 0.0
 
 
 class TestPolynomial:


### PR DESCRIPTION
Found issues with linear fitting whereby the guess function would not work as expected e.g not guessing a straight line and division by zero error. This fixes by instead using the already implemented polynomial guess function and passing 1 as the polynomial degree. Should test by creating an example plan and two blocks to scan against eachother from- use a python script to repeatedly write to one of the blocks to simulate data from scan. See below. Check that initial guess produced in plot window fits the data provided well.

See [fitting docs](https://isiscomputinggroup.github.io/ibex_bluesky_core/fitting/fitting.html) for more info.

Run this separately

```
def linear(x, m, c):
    return m * x + c

g.set_pv("CS:SB:bob", 1, is_local=True)

while True:

    val = g.get_pv("CS:SB:bob", is_local=True)
    g.set_pv("CS:SB:alice", linear(val, 0, 1),is_local=True)
```

Use a plan that looks like this

```
def plan():

    alice = block_r(float, "alice")
    bob = block_rw(float, "bob", write_config=BlockWriteConfig(settle_time_s=0.5))

    lf = LiveFit(Linear.fit(), "alice", "bob")

    fig, ax = plt.subplots()
    
    @subs_decorator(
        [
            LiveTable([bob.name, alice.name]),
            LiveFitPlot(lf, ax=ax, color="r", num_points=1000),
            LivePlot(y=alice.name, x=bob.name, ax=ax, marker="x", linestyle="none"),
        ]
    )
    def _inner() -> Generator[Msg, None, None]:
        yield from ensure_connected(bob, alice)
        yield from bp.scan([alice], bob, -5, 5, num=15)
        logger.blueskylogger.info("Some useful message")
    yield from _inner()
```

