### PR TITLE
Add helper for external blocking functions

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -101,6 +101,13 @@ Reference documentation
 
 .. toctree::
    :maxdepth: 2
+   :caption: Plan stubs
+   :glob:
+
+   plan_stubs/*
+
+.. toctree::
+   :maxdepth: 2
    :caption: Preprocessors
    :glob:
 

--- a/doc/plan_stubs/external_code.md
+++ b/doc/plan_stubs/external_code.md
@@ -1,5 +1,7 @@
 # `call_sync` (calling external code)
 
+API reference: {py:obj}`ibex_bluesky_core.plan_stubs.call_sync`
+
 All interaction with the "outside world" should be via bluesky messages, and **not** directly called from
 within a plan. For example, the following is **bad**:
 

--- a/doc/plan_stubs/external_code.md
+++ b/doc/plan_stubs/external_code.md
@@ -1,0 +1,75 @@
+# `call_sync` (calling external code)
+
+All interaction with the "outside world" should be via bluesky messages, and **not** directly called from
+within a plan. For example, the following is **bad**:
+
+```python
+import bluesky.plan_stubs as bps
+from genie_python import genie as g
+
+def bad_plan():
+    yield from bps.open_run()
+    g.cset("foo", 123)  # This is bad - must not do this
+    yield from bps.close_run()
+```
+
+```{danger}
+External I/O - including most `genie_python` or `inst` functions -  should never be done directly in a plan,
+as it will break:
+- Rewindability (for example, the ability to interrupt a scan and then later seamlessly continue it)
+- Simulation (the `cset` above would be executed during a simulation)
+- Error handling (including ctrl-c handling)
+- Ability to emit documents
+- Ability to use bluesky signals
+- ...
+```
+
+In the above case, a good plan, which uses bluesky messages in a better way using 
+a bluesky-native `Block` object, would be:
+
+```python
+import bluesky.plan_stubs as bps
+from ophyd_async.plan_stubs import ensure_connected
+from ibex_bluesky_core.devices.block import block_rw
+
+foo = block_rw(float, "foo")
+
+def good_plan():
+    yield from ensure_connected(foo)
+    yield from bps.open_run()
+    yield from bps.mv(foo, 123)
+    yield from bps.close_run()
+```
+
+However, if the functionality you want to use is not yet natively available in bluesky, a fallback option
+for synchronous functions is available using the `call_sync` plan stub:
+
+```python
+import bluesky.plan_stubs as bps
+from ibex_bluesky_core.plan_stubs import call_sync
+from genie_python import genie as g
+
+def good_plan():
+    yield from bps.open_run()
+    
+    # Note use of g.some_function, rather than g.some_function() - i.e. a function reference
+    # We can also access the returned value from the call.
+    return_value = yield from call_sync(g.some_function, 123, keyword_argument=456)
+    yield from bps.checkpoint()
+    yield from bps.close_run()
+```
+
+It is strongly recommended that any functions run in this way are "fast" (i.e. less than a few seconds).
+In particular, avoid doing arbitrarily-long waits - for example, waiting for detector data
+or sample environment. For these long-running tasks, seek to implement at least the long-running parts using 
+native bluesky mechanisms.
+
+```{note}
+`bps.checkpoint()` above instructs bluesky that this is a safe point from which to resume a plan. 
+`call_sync` always clears an active checkpoint first, as the code it runs may have arbitrary external
+side effects.
+
+If a plan is interrupted with no checkpoint active, it cannot be resumed later (it effectively forces
+the plan to abort rather than pause). You will see `bluesky.utils.FailedPause` as part of the traceback
+on ctrl-c, if this is the case.
+```

--- a/src/ibex_bluesky_core/plan_stubs/__init__.py
+++ b/src/ibex_bluesky_core/plan_stubs/__init__.py
@@ -1,6 +1,6 @@
 """Core plan stubs."""
 
-from typing import Callable, Generator, ParamSpec, TypeVar
+from typing import Callable, Generator, ParamSpec, TypeVar, cast
 
 import bluesky.plan_stubs as bps
 from bluesky.utils import Msg
@@ -12,9 +12,7 @@ T = TypeVar("T")
 CALL_SYNC_MSG_KEY = "ibex_bluesky_core_call_sync"
 
 
-def call_sync(
-    func: Callable[P, T], *args: P.args, **kwargs: P.kwargs
-) -> Generator[Msg, None, None]:
+def call_sync(func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> Generator[Msg, None, T]:
     """Call a synchronous user function in a plan, and returns the result of that call.
 
     Attempts to guard against the most common pitfalls of naive implementations, for example:
@@ -41,4 +39,4 @@ def call_sync(
 
     """
     yield from bps.clear_checkpoint()
-    return (yield Msg(CALL_SYNC_MSG_KEY, func, *args, **kwargs))
+    return cast(T, (yield Msg(CALL_SYNC_MSG_KEY, func, *args, **kwargs)))

--- a/src/ibex_bluesky_core/plan_stubs/__init__.py
+++ b/src/ibex_bluesky_core/plan_stubs/__init__.py
@@ -1,1 +1,44 @@
 """Core plan stubs."""
+
+from typing import Callable, Generator, ParamSpec, TypeVar
+
+import bluesky.plan_stubs as bps
+from bluesky.utils import Msg
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+CALL_SYNC_MSG_KEY = "ibex_bluesky_core_call_sync"
+
+
+def call_sync(
+    func: Callable[P, T], *args: P.args, **kwargs: P.kwargs
+) -> Generator[Msg, None, None]:
+    """Call a synchronous user function in a plan, and returns the result of that call.
+
+    Attempts to guard against the most common pitfalls of naive implementations, for example:
+    - Blocking the whole event loop
+    - Breaking keyboard interrupt handling
+    - Not clearing the active checkpoint
+
+    It does not necessarily guard against all possible cases, and as such it is *recommended* to
+    use native bluesky functionality wherever possible in preference to this plan stub. This should
+    be seen as an escape-hatch.
+
+    The wrapped function will be run in a new thread.
+
+    This plan stub will clear any active checkpoints before running the external code, because
+    in general the external code is not safe to re-run later once it has started (e.g. it may have
+    done relative sets, or may have started some external process). This means that if a plan is
+    interrupted at any point between a call_sync and the next checkpoint, the plan cannot be
+    resumed - in this case bluesky.utils.FailedPause will appear in the ctrl-c stack trace.
+
+    Args:
+        func: A callable to run.
+        args: Arbitrary arguments to be passed to the wrapped function
+        kwargs: Arbitrary keyword arguments to be passed to the wrapped function
+
+    """
+    yield from bps.clear_checkpoint()
+    return (yield Msg(CALL_SYNC_MSG_KEY, func, *args, **kwargs))

--- a/src/ibex_bluesky_core/plan_stubs/__init__.py
+++ b/src/ibex_bluesky_core/plan_stubs/__init__.py
@@ -16,6 +16,7 @@ def call_sync(func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> Genera
     """Call a synchronous user function in a plan, and returns the result of that call.
 
     Attempts to guard against the most common pitfalls of naive implementations, for example:
+
     - Blocking the whole event loop
     - Breaking keyboard interrupt handling
     - Not clearing the active checkpoint

--- a/src/ibex_bluesky_core/run_engine/__init__.py
+++ b/src/ibex_bluesky_core/run_engine/__init__.py
@@ -14,7 +14,9 @@ from ibex_bluesky_core.callbacks.document_logger import DocLoggingCallback
 
 __all__ = ["get_run_engine"]
 
+from ibex_bluesky_core.plan_stubs import CALL_SYNC_MSG_KEY
 from ibex_bluesky_core.preprocessors import add_rb_number_processor
+from ibex_bluesky_core.run_engine._msg_handlers import call_sync_handler
 
 
 class _DuringTask(DuringTask):
@@ -88,6 +90,8 @@ def get_run_engine() -> RunEngine:
 
     log_callback = DocLoggingCallback()
     RE.subscribe(log_callback)
+
+    RE.register_command(CALL_SYNC_MSG_KEY, call_sync_handler)
 
     RE.preprocessors.append(functools.partial(bpp.plan_mutator, msg_proc=add_rb_number_processor))
 

--- a/src/ibex_bluesky_core/run_engine/_msg_handlers.py
+++ b/src/ibex_bluesky_core/run_engine/_msg_handlers.py
@@ -1,0 +1,81 @@
+"""Private helper module for run engine message handlers.
+
+Not intended for user use.
+"""
+
+import ctypes
+import threading
+from asyncio import CancelledError, Event, get_running_loop
+from typing import Any
+
+from bluesky.utils import Msg
+
+
+class _ExternalFunctionInterrupted(BaseException):
+    """An external sync function running in a worker thread is being interrupted."""
+
+
+async def call_sync_handler(msg: Msg) -> Any:  # noqa: ANN401
+    """Handle ibex_bluesky_core.plan_stubs.call_sync."""
+    func = msg.obj
+    ret = None
+    exc: BaseException | None = None
+    done_event = Event()
+    loop = get_running_loop()
+
+    def _wrapper() -> Any:  # noqa: ANN401
+        try:
+            nonlocal ret
+            ret = func(*msg.args, **msg.kwargs)
+        except _ExternalFunctionInterrupted:
+            pass  # Suppress stack traces from our special interruption exception.
+        except BaseException as e:
+            nonlocal exc
+            exc = e
+            raise
+        finally:
+            loop.call_soon_threadsafe(done_event.set)
+
+    worker_thread = threading.Thread(target=_wrapper, name="external_function_worker", daemon=True)
+    worker_thread.start()
+
+    try:
+        # Wait until done event is set.
+        # Ensure we're not blocking the whole event loop while waiting.
+        await done_event.wait()
+    except (KeyboardInterrupt, CancelledError):
+        # We got interrupted while the external function thread was running.
+        #
+        # A few options:
+        # - We could hang until the external function returns (not ideal, in principle it could
+        #   be a rather long-running external function, so would prevent the interrupt from working)
+        # - Interrupt but don't actually kill the thread, this leads to a misleading result where
+        #   a user gets the shell back but the task is still running in the background
+        # - Hack around with ctypes to inject an injection into the thread running the external
+        #   function. This is generally frowned upon as a bad idea, but may be the "least bad"
+        #   solution to running potentially-blocking user code within a plan.
+        # - Force users to pass in coroutines (which await regularly) or functions which check some
+        #   global interrupt flag regularly. Unlikely to be able to persuade users to do this in
+        #   general.
+        #
+        # A few notes on PyThreadState_SetAsyncExc:
+        # - It is used by bluesky here, for a similar case:
+        #   https://github.com/bluesky/bluesky/blob/v1.13.0a4/src/bluesky/run_engine.py#L1074
+        # - The documentation for this function includes the line
+        #   "To prevent naive misuse, you must write your own C extension to call this."
+        #   (Like bluesky, I have cheated by using ctypes instead of C)
+        # - It may not be fully reliable, in general. It is possible for the async exception to be
+        #   cleared in native code (and thus "ignored"). We can't wait for the thread to die, as it
+        #   may be in a long-running system call that won't notice this exception until it returns
+        #   to python code. This is still felt to be better-than-nothing.
+        #
+        thread_id = worker_thread.ident
+        assert thread_id is not None, "Can't find worker thread to kill it"
+        n_threads = ctypes.pythonapi.PyThreadState_SetAsyncExc(
+            ctypes.c_ulong(thread_id), ctypes.py_object(_ExternalFunctionInterrupted)
+        )
+        assert n_threads <= 1, f"Raised async exception in multiple ({n_threads}) threads!"
+        raise
+    if exc is not None:
+        raise exc
+    return ret

--- a/tests/test_plan_stubs.py
+++ b/tests/test_plan_stubs.py
@@ -1,0 +1,68 @@
+# pyright: reportMissingParameterType=false
+
+import time
+from asyncio import CancelledError
+from unittest.mock import patch
+
+import pytest
+from bluesky.utils import Msg
+
+from ibex_bluesky_core.plan_stubs import call_sync
+from ibex_bluesky_core.run_engine._msg_handlers import call_sync_handler
+
+
+def test_call_sync_returns_result(RE):
+    def f(arg, keyword_arg):
+        assert arg == "foo"
+        assert keyword_arg == "bar"
+        return 123
+
+    result = RE(call_sync(f, "foo", keyword_arg="bar"))
+
+    assert result.plan_result == 123
+
+
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
+def test_call_sync_throws_exception(RE):
+    def f():
+        raise ValueError("broke it")
+
+    with pytest.raises(ValueError, match="broke it"):
+        RE(call_sync(f))
+
+
+@pytest.mark.parametrize("err", [(KeyboardInterrupt,), (CancelledError,)])
+async def test_call_sync_handler_blocking_python(err: type[BaseException]):
+    def f():
+        while True:
+            pass
+
+    with patch("ibex_bluesky_core.run_engine._msg_handlers.Event") as evt:
+        evt.return_value.wait.side_effect = err
+        msg = Msg("", f)
+        with pytest.raises(err):
+            await call_sync_handler(msg)
+
+
+@pytest.mark.parametrize("err", [(KeyboardInterrupt,), (CancelledError,)])
+async def test_call_sync_handler_blocking_native(err: type[BaseException]):
+    def f():
+        while True:
+            time.sleep(1)
+
+    with patch("ibex_bluesky_core.run_engine._msg_handlers.Event") as evt:
+        evt.return_value.wait.side_effect = err
+        msg = Msg("", f)
+        with pytest.raises(err):
+            await call_sync_handler(msg)
+
+
+def test_call_sync_waits_for_completion(RE):
+    def f():
+        time.sleep(1)
+
+    start = time.monotonic()
+    RE(call_sync(f))
+    end = time.monotonic()
+
+    assert end - start == pytest.approx(1, abs=0.2)


### PR DESCRIPTION
https://github.com/ISISComputingGroup/ibex_bluesky_core/issues/43

Contrary to what the ticket said, I did actually end up writing some code rather than just documentation here. My initial plan was to simply not allow keyboard interrupts, but on further thought I think a best-efforts mechanism, while not _perfect_ is better than nothing.

There's some fiddly code in this PR so please review carefully and make sure it is understandable for the average developer.