### PR TITLE
add action for checking every day against ophyd-async and bluesky main branches

### DIFF
--- a/.github/workflows/test-against-main.yml
+++ b/.github/workflows/test-against-main.yml
@@ -3,11 +3,6 @@ on:
   schedule:
     - cron: "0 0 * * *"
 jobs:
-  call-linter-workflow:
-    uses: ISISComputingGroup/reusable-workflows/.github/workflows/linters.yml@main
-    with:
-      compare-branch: origin/main
-      python-ver: '3.11'
   tests:
     runs-on: ubuntu-latest
     strategy:
@@ -22,13 +17,17 @@ jobs:
         run: pip install -e .[dev]
       - name: install latest bluesky and ophyd-async
         run: pip install --upgrade --force-reinstall git+https://github.com/bluesky/bluesky.git@main git+https://github.com/bluesky/ophyd-async.git@main
+      - name: run ruff
+        run: python -m ruff --check
+      - name: run pyright
+        run: python -m pyright
       - name: run pytest
         run: python -m pytest
   results:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     name: Final Results
-    needs: [call-linter-workflow, tests]
+    needs: [tests]
     steps:
     - run: exit 1
       # see https://stackoverflow.com/a/67532120/4907315

--- a/.github/workflows/test-against-main.yml
+++ b/.github/workflows/test-against-main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['3.10','3.11'] # ,'3.12'] # also check on 3.12 once https://github.com/bluesky/ophyd-async/pull/478 is merged.
+        version: ['3.11', "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/test-against-main.yml
+++ b/.github/workflows/test-against-main.yml
@@ -1,0 +1,39 @@
+name: test-against-main
+on:
+  schedule:
+    - cron: "0 0 * * *"
+jobs:
+  call-linter-workflow:
+    uses: ISISComputingGroup/reusable-workflows/.github/workflows/linters.yml@main
+    with:
+      compare-branch: origin/main
+      python-ver: '3.11'
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: ['3.10','3.11'] # ,'3.12'] # also check on 3.12 once https://github.com/bluesky/ophyd-async/pull/478 is merged.
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.version }}
+      - name: install requirements
+        run: pip install -e .[dev]
+      - name: install latest bluesky and ophyd-async
+        run: pip install --upgrade --force-reinstall git+https://github.com/bluesky/bluesky.git@main git+https://github.com/bluesky/ophyd-async.git@main
+      - name: run pytest
+        run: python -m pytest
+  results:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Final Results
+    needs: [call-linter-workflow, tests]
+    steps:
+    - run: exit 1
+      # see https://stackoverflow.com/a/67532120/4907315
+      if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+          }}


### PR DESCRIPTION
may close #49 

this is difficult to test as [the action will only work on the main branch](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule):
> This event will only trigger a workflow run if the workflow file is on the default branch.

