### PR TITLE
Force legend to be drawn

### DIFF
--- a/src/ibex_bluesky_core/callbacks/plotting.py
+++ b/src/ibex_bluesky_core/callbacks/plotting.py
@@ -50,6 +50,7 @@ class LivePlot(_DefaultLivePlot):
         """
         if "genie_python" in matplotlib.get_backend():
             logger.debug("Explicitly show()ing plot for IBEX")
+            plt.legend()
             plt.show()
 
     def event(self, doc: Event) -> None:


### PR DESCRIPTION
Fixes https://github.com/ISISComputingGroup/ibex_bluesky_core/issues/69

Happens if a fit guess doesn't have enough parameters on first point to generate a line.