### PR TITLE
Bump sigstore

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
         name: python-package-distributions
         path: dist/
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v2.1.1
+      uses: sigstore/gh-action-sigstore-python@v3.0.0
       with:
         inputs: >-
           ./dist/*.tar.gz


### PR DESCRIPTION
Last release [failed sigstore](https://github.com/ISISComputingGroup/ibex_bluesky_core/actions/runs/12064270880/job/33687930925), bump it up a version as per [updated pypa recommendation](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/) to see if that helps.

If so, will make an equivalent pr on `genie` too.