### PR TITLE
Helper to create a new figure/axes in a qt-safe way

### DIFF
--- a/doc/callbacks/plotting.md
+++ b/doc/callbacks/plotting.md
@@ -31,15 +31,23 @@ to plot a scan with a logarithmically-scaled y-axis:
 ```python
 import matplotlib.pyplot as plt
 from ibex_bluesky_core.callbacks.plotting import LivePlot
-# Create a new figure to plot onto.
-plt.figure()
-# Make a new set of axes on that figure
-ax = plt.gca()
-# Set the y-scale to logarithmic
-ax.set_yscale("log")
-# Use the above axes in a LivePlot callback
-plot_callback = LivePlot(y="y_variable", x="x_variable", ax=ax, yerr="yerr_variable")
-# yerr is the uncertanties of each y value, producing error bars
+from ibex_bluesky_core.plan_stubs import call_qt_aware
+
+def plan():
+    # Create a new figure to plot onto.
+    yield from call_qt_aware(plt.figure)
+    # Make a new set of axes on that figure
+    ax = yield from call_qt_aware(plt.gca)
+    # Set the y-scale to logarithmic
+    yield from call_qt_aware(ax.set_yscale, "log")
+    # Use the above axes in a LivePlot callback
+    plot_callback = LivePlot(y="y_variable", x="x_variable", ax=ax, yerr="yerr_variable")
+    # yerr is the uncertanties of each y value, producing error bars
+```
+
+```{note}
+See [docs for `call_qt_aware`](../plan_stubs/matplotlib_helpers.md) for a description of why we need to use 
+`yield from call_qt_aware` rather than calling `matplotlib` functions directly.
 ```
 
 By providing a signal name to the `yerr` argument you can pass uncertainties to LivePlot, by not providing anything for this argument means that no errorbars will be drawn. Errorbars are drawn after each point collected, displaying their standard deviation- uncertainty data is collected from Bluesky event documents and errorbars are updated after every new point added.

--- a/doc/plan_stubs/matplotlib_helpers.md
+++ b/doc/plan_stubs/matplotlib_helpers.md
@@ -1,0 +1,51 @@
+# `matplotlib` helpers
+
+When attempting to use `matplotlib` UI functions directly in a plan, and running `matplotlib` using a `Qt`
+backend (e.g. in a standalone shell outside IBEX), you may see an error of the form:
+
+```
+UserWarning: Starting a Matplotlib GUI outside of the main thread will likely fail.
+  fig, ax = plt.subplots()
+```
+
+This is because the `RunEngine` runs plans in a worker thread, not in the main thread, which then requires special
+handling when calling functions that will update a UI.
+
+The following plan stubs provide Qt-safe wrappers around some matplotlib functions to avoid this error.
+
+```{note}
+Callbacks such as `LivePlot` and `LiveFitPlot` already route UI calls to the appropriate UI thread by default. 
+The following plan stubs are only necessary if you need to call functions which will create or update a matplotlib
+plot from a plan directly.
+```
+
+## `matplotlib_subplots`
+
+The {py:obj}`ibex_bluesky_core.plan_stubs.matplotlib_subplots` plan stub is a Qt-safe wrapper 
+around `matplotlib.pyplot.subplots()`. It allows the same arguments and keyword-arguments as the 
+underlying matplotlib function.
+
+Usage example:
+
+```python
+from ibex_bluesky_core.plan_stubs import matplotlib_subplots
+from ibex_bluesky_core.callbacks.plotting import LivePlot
+from bluesky.callbacks import LiveFitPlot
+from bluesky.preprocessors import subs_decorator
+
+def my_plan():
+    # BAD
+    # fig, ax = plt.subplots()
+    
+    # GOOD
+    fig, ax = yield from matplotlib_subplots()
+    
+    # Pass the matplotlib ax object to other callbacks
+    @subs_decorator([
+        LiveFitPlot(..., ax=ax),
+        LivePlot(..., ax=ax),
+    ])
+    def inner_plan():
+        ...
+```
+

--- a/doc/plan_stubs/matplotlib_helpers.md
+++ b/doc/plan_stubs/matplotlib_helpers.md
@@ -36,10 +36,10 @@ from bluesky.preprocessors import subs_decorator
 def my_plan():
     # BAD
     # fig, ax = plt.subplots()
-    
+
     # GOOD
     fig, ax = yield from matplotlib_subplots()
-    
+
     # Pass the matplotlib ax object to other callbacks
     @subs_decorator([
         LiveFitPlot(..., ax=ax),

--- a/manual_system_tests/dae_scan.py
+++ b/manual_system_tests/dae_scan.py
@@ -27,7 +27,7 @@ from ibex_bluesky_core.devices.simpledae.reducers import (
     GoodFramesNormalizer,
 )
 from ibex_bluesky_core.devices.simpledae.waiters import GoodFramesWaiter
-from ibex_bluesky_core.plan_stubs import matplotlib_subplots
+from ibex_bluesky_core.plan_stubs import call_qt_aware
 from ibex_bluesky_core.run_engine import get_run_engine
 
 NUM_POINTS: int = 3
@@ -72,7 +72,7 @@ def dae_scan_plan() -> Generator[Msg, None, None]:
     controller.run_number.set_name("run number")
     reducer.intensity.set_name("normalized counts")
 
-    _, ax = yield from matplotlib_subplots()
+    _, ax = yield from call_qt_aware(plt.subplots)
 
     lf = LiveFit(
         Linear.fit(), y=reducer.intensity.name, x=block.name, yerr=reducer.intensity_stddev.name

--- a/manual_system_tests/dae_scan.py
+++ b/manual_system_tests/dae_scan.py
@@ -27,6 +27,7 @@ from ibex_bluesky_core.devices.simpledae.reducers import (
     GoodFramesNormalizer,
 )
 from ibex_bluesky_core.devices.simpledae.waiters import GoodFramesWaiter
+from ibex_bluesky_core.plan_stubs import new_matplotlib_figure_and_axes
 from ibex_bluesky_core.run_engine import get_run_engine
 
 NUM_POINTS: int = 3
@@ -71,7 +72,8 @@ def dae_scan_plan() -> Generator[Msg, None, None]:
     controller.run_number.set_name("run number")
     reducer.intensity.set_name("normalized counts")
 
-    _, ax = plt.subplots()
+    _, ax = yield from new_matplotlib_figure_and_axes()
+
     lf = LiveFit(
         Linear.fit(), y=reducer.intensity.name, x=block.name, yerr=reducer.intensity_stddev.name
     )

--- a/manual_system_tests/dae_scan.py
+++ b/manual_system_tests/dae_scan.py
@@ -27,7 +27,7 @@ from ibex_bluesky_core.devices.simpledae.reducers import (
     GoodFramesNormalizer,
 )
 from ibex_bluesky_core.devices.simpledae.waiters import GoodFramesWaiter
-from ibex_bluesky_core.plan_stubs import new_matplotlib_figure_and_axes
+from ibex_bluesky_core.plan_stubs import matplotlib_subplots
 from ibex_bluesky_core.run_engine import get_run_engine
 
 NUM_POINTS: int = 3
@@ -72,7 +72,7 @@ def dae_scan_plan() -> Generator[Msg, None, None]:
     controller.run_number.set_name("run number")
     reducer.intensity.set_name("normalized counts")
 
-    _, ax = yield from new_matplotlib_figure_and_axes()
+    _, ax = yield from matplotlib_subplots()
 
     lf = LiveFit(
         Linear.fit(), y=reducer.intensity.name, x=block.name, yerr=reducer.intensity_stddev.name

--- a/src/ibex_bluesky_core/plan_stubs/__init__.py
+++ b/src/ibex_bluesky_core/plan_stubs/__init__.py
@@ -1,15 +1,28 @@
 """Core plan stubs."""
 
-from typing import Callable, Generator, ParamSpec, TypeVar, cast
+import threading
+from collections.abc import Generator
+from typing import Callable, ParamSpec, TypeVar, cast
 
 import bluesky.plan_stubs as bps
+import matplotlib.pyplot as plt
+from bluesky.callbacks.mpl_plotting import QtAwareCallback
 from bluesky.utils import Msg
+from event_model import RunStart
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 
 P = ParamSpec("P")
 T = TypeVar("T")
 
 
+PYPLOT_SUBPLOTS_TIMEOUT = 5
+
+
 CALL_SYNC_MSG_KEY = "ibex_bluesky_core_call_sync"
+
+
+__all__ = ["call_sync", "new_matplotlib_figure_and_axes"]
 
 
 def call_sync(func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> Generator[Msg, None, T]:
@@ -41,3 +54,53 @@ def call_sync(func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> Genera
     """
     yield from bps.clear_checkpoint()
     return cast(T, (yield Msg(CALL_SYNC_MSG_KEY, func, *args, **kwargs)))
+
+
+def new_matplotlib_figure_and_axes(
+    *args: list, **kwargs: dict
+) -> Generator[Msg, None, tuple[Figure, Axes]]:
+    """Create a new matplotlib figure and axes, using plt.subplots, from within a plan.
+
+    This is done in a Qt-safe way, such that if matplotlib is using the Qt backend then
+    UI operations need to be run on the Qt thread via Qt signals.
+
+    Args:
+        args: Arbitrary arguments, passed through to matplotlib.pyplot.subplots
+        kwargs: Arbitrary keyword arguments, passed through to matplotlib.pyplot.subplots
+
+    Returns:
+        tuple of (figure, axes) - as per matplotlib.pyplot.subplots()
+
+    """
+    yield from bps.null()
+
+    ev = threading.Event()
+    fig: Figure | None = None
+    ax: Axes | None = None
+    ex: BaseException | None = None
+
+    # Slightly hacky, this isn't really a callback per-se but we want to benefit from
+    # bluesky's Qt-matplotlib infrastructure.
+    # This never gets attached to the RunEngine.
+    class _Cb(QtAwareCallback):
+        def start(self, _: RunStart) -> None:
+            nonlocal fig, ax, ex
+            # Note: this is "fast" - so don't need to worry too much about
+            # interruption case.
+            try:
+                fig, ax = plt.subplots(*args, **kwargs)
+            except BaseException as e:
+                ex = e
+            finally:
+                ev.set()
+
+    cb = _Cb()
+    # Send fake event to our callback to trigger it (actual contents unimportant)
+    cb("start", {"time": 0, "uid": ""})
+    if not ev.wait(PYPLOT_SUBPLOTS_TIMEOUT):
+        raise OSError("Could not create matplotlib figure and axes (timeout)")
+    if fig is None or ax is None:
+        raise OSError(
+            "Could not create matplotlib figure and axes (got fig=%s, ax=%s, ex=%s)", fig, ax, ex
+        )
+    return fig, ax

--- a/src/ibex_bluesky_core/plan_stubs/__init__.py
+++ b/src/ibex_bluesky_core/plan_stubs/__init__.py
@@ -51,7 +51,8 @@ def call_sync(func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> Genera
 
 
 def matplotlib_subplots(
-    *args: list[Any], **kwargs: dict[Any]
+    *args: Any,  # noqa: ANN401 - pyright doesn't understand we're wrapping mpl API.
+    **kwargs: Any,  # noqa: ANN401 - pyright doesn't understand we're wrapping mpl API.
 ) -> Generator[Msg, None, tuple[Figure, Any]]:
     """Create a new matplotlib figure and axes, using matplotlib.pyplot.subplots, from a plan.
 

--- a/src/ibex_bluesky_core/run_engine/__init__.py
+++ b/src/ibex_bluesky_core/run_engine/__init__.py
@@ -17,8 +17,8 @@ from ibex_bluesky_core.preprocessors import add_rb_number_processor
 __all__ = ["get_run_engine"]
 
 
-from ibex_bluesky_core.plan_stubs import CALL_SYNC_MSG_KEY
-from ibex_bluesky_core.run_engine._msg_handlers import call_sync_handler
+from ibex_bluesky_core.plan_stubs import CALL_QT_SAFE_MSG_KEY, CALL_SYNC_MSG_KEY
+from ibex_bluesky_core.run_engine._msg_handlers import call_qt_safe_handler, call_sync_handler
 
 logger = logging.getLogger(__name__)
 
@@ -97,6 +97,7 @@ def get_run_engine() -> RunEngine:
     RE.subscribe(log_callback)
 
     RE.register_command(CALL_SYNC_MSG_KEY, call_sync_handler)
+    RE.register_command(CALL_QT_SAFE_MSG_KEY, call_qt_safe_handler)
 
     RE.preprocessors.append(functools.partial(bpp.plan_mutator, msg_proc=add_rb_number_processor))
 

--- a/src/ibex_bluesky_core/run_engine/__init__.py
+++ b/src/ibex_bluesky_core/run_engine/__init__.py
@@ -17,8 +17,8 @@ from ibex_bluesky_core.preprocessors import add_rb_number_processor
 __all__ = ["get_run_engine"]
 
 
-from ibex_bluesky_core.plan_stubs import CALL_QT_SAFE_MSG_KEY, CALL_SYNC_MSG_KEY
-from ibex_bluesky_core.run_engine._msg_handlers import call_qt_safe_handler, call_sync_handler
+from ibex_bluesky_core.plan_stubs import CALL_QT_AWARE_MSG_KEY, CALL_SYNC_MSG_KEY
+from ibex_bluesky_core.run_engine._msg_handlers import call_qt_aware_handler, call_sync_handler
 
 logger = logging.getLogger(__name__)
 
@@ -97,7 +97,7 @@ def get_run_engine() -> RunEngine:
     RE.subscribe(log_callback)
 
     RE.register_command(CALL_SYNC_MSG_KEY, call_sync_handler)
-    RE.register_command(CALL_QT_SAFE_MSG_KEY, call_qt_safe_handler)
+    RE.register_command(CALL_QT_AWARE_MSG_KEY, call_qt_aware_handler)
 
     RE.preprocessors.append(functools.partial(bpp.plan_mutator, msg_proc=add_rb_number_processor))
 

--- a/tests/test_plan_stubs.py
+++ b/tests/test_plan_stubs.py
@@ -1,13 +1,14 @@
 # pyright: reportMissingParameterType=false
-
+import re
 import time
 from asyncio import CancelledError
 from unittest.mock import patch
 
+import matplotlib
 import pytest
 from bluesky.utils import Msg
 
-from ibex_bluesky_core.plan_stubs import call_sync
+from ibex_bluesky_core.plan_stubs import CALL_QT_SAFE_MSG_KEY, call_sync, matplotlib_subplots
 from ibex_bluesky_core.run_engine._msg_handlers import call_sync_handler
 
 
@@ -66,3 +67,56 @@ def test_call_sync_waits_for_completion(RE):
     end = time.monotonic()
 
     assert end - start == pytest.approx(1, abs=0.2)
+
+
+def test_call_qt_safe_returns_result(RE):
+    def f(arg, keyword_arg):
+        assert arg == "foo"
+        assert keyword_arg == "bar"
+        return 123
+
+    def plan():
+        return (yield Msg(CALL_QT_SAFE_MSG_KEY, f, "foo", keyword_arg="bar"))
+
+    result = RE(plan())
+
+    assert result.plan_result == 123
+
+
+def test_call_qt_safe_throws_exception(RE):
+    def f():
+        raise ValueError("broke it")
+
+    def plan():
+        return (yield Msg(CALL_QT_SAFE_MSG_KEY, f))
+
+    with pytest.raises(ValueError, match="broke it"):
+        RE(plan())
+
+
+@pytest.mark.skipif("qt" not in matplotlib.get_backend().lower(), reason="Qt not available")
+def test_call_qt_safe_blocking_causes_descriptive_timeout_error(RE):
+    def f():
+        time.sleep(0.2)
+
+    def plan():
+        return (yield Msg(CALL_QT_SAFE_MSG_KEY, f))
+
+    with patch("ibex_bluesky_core.run_engine._msg_handlers.CALL_QT_SAFE_TIMEOUT", new=0.1):
+        with pytest.raises(
+            TimeoutError,
+            match=re.escape(
+                "Long-running function 'f' passed to call_qt_safe_handler. "
+                "Functions passed to call_qt_safe_handler must be faster than 0.1s."
+            ),
+        ):
+            RE(plan())
+
+
+def test_matplotlib_subplots_calls_pyplot_subplots(RE):
+    def plan():
+        return (yield from matplotlib_subplots("foo", keyword="bar"))
+
+    with patch("ibex_bluesky_core.plan_stubs.plt.subplots") as mock_pyplot_subplots:
+        RE(plan())
+        mock_pyplot_subplots.assert_called_once_with("foo", keyword="bar")


### PR DESCRIPTION
Fixes https://github.com/ISISComputingGroup/ibex_bluesky_core/issues/92

Calling `plt.subplots` directly in a plan breaks, if the matplotlib backend is `qt` (e.g. if running a plan in a standalone shell).

That's because it would try to interact with the Qt gui from the RunEngine's plan worker thread, which is invalid. Instead we need to force it to go through bluesky's matplotlib-qt integration infrastructure.

To review:
- Run manual dae_scan plan in IBEX
- Run manual dae_scan plan in a standalone window (this _doesn't_ currently work on `main`)
- Both cases above should run and display plots
- Docs are clear enough