### PR TITLE
make test-against-main not fail fast

### DIFF
--- a/.github/workflows/test-against-main.yml
+++ b/.github/workflows/test-against-main.yml
@@ -6,6 +6,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         version: ['3.11', "3.12"]
     steps:


### PR DESCRIPTION
we probably want to know if tests are failing even if ruff/pyright fails