### PR TITLE
use uv in CI

### DIFF
--- a/.github/workflows/Lint-and-test.yml
+++ b/.github/workflows/Lint-and-test.yml
@@ -31,9 +31,11 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.version }}
+      - name: install uv
+        run: python -m pip install uv
       - name: install requirements
         run: uv pip install -e .[dev]
       - name: run pytest (linux)

--- a/.github/workflows/Lint-and-test.yml
+++ b/.github/workflows/Lint-and-test.yml
@@ -31,11 +31,11 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.version }}
       - name: install requirements
-        run: pip install -e .[dev]
+        run: uv pip install -e .[dev]
       - name: run pytest (linux)
         run: IBEX_BLUESKY_CORE_LOGS=/tmp/ibex_bluesky_core_logs/ python -m pytest
         if: startsWith(matrix.os,'ubuntu')

--- a/.github/workflows/Lint-and-test.yml
+++ b/.github/workflows/Lint-and-test.yml
@@ -38,15 +38,17 @@ jobs:
         run: python -m pip install uv
       - name: venv
         run: uv venv .venv
-      - name: setuptools
-        run: uv pip install setuptools==75.9.1
       - name: install requirements
         run: uv pip install -e .[dev]
       - name: run pytest (linux)
-        run: IBEX_BLUESKY_CORE_LOGS=/tmp/ibex_bluesky_core_logs/ uv run pytest
+        run: |
+          source .venv/bin/activate
+          IBEX_BLUESKY_CORE_LOGS=/tmp/ibex_bluesky_core_logs/ python -m pytest
         if: startsWith(matrix.os,'ubuntu')
       - name: run pytest (windows)
-        run: uv run pytest
+        run: |
+          .venv\\scripts\\activate
+          python -m pytest
         if: startsWith(matrix.os,'windows')
   results:
     if: ${{ always() }}

--- a/.github/workflows/Lint-and-test.yml
+++ b/.github/workflows/Lint-and-test.yml
@@ -41,10 +41,10 @@ jobs:
       - name: install requirements
         run: uv pip install -e .[dev]
       - name: run pytest (linux)
-        run: IBEX_BLUESKY_CORE_LOGS=/tmp/ibex_bluesky_core_logs/ python -m pytest
+        run: IBEX_BLUESKY_CORE_LOGS=/tmp/ibex_bluesky_core_logs/ uv run pytest
         if: startsWith(matrix.os,'ubuntu')
       - name: run pytest (windows)
-        run: python -m pytest
+        run: uv run pytest
         if: startsWith(matrix.os,'windows')
   results:
     if: ${{ always() }}

--- a/.github/workflows/Lint-and-test.yml
+++ b/.github/workflows/Lint-and-test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: venv
         run: uv venv .venv
       - name: setuptools
-        run: uv pip install --upgrade setuptools
+        run: uv pip install setuptools==75.9.1
       - name: install requirements
         run: uv pip install -e .[dev]
       - name: run pytest (linux)

--- a/.github/workflows/Lint-and-test.yml
+++ b/.github/workflows/Lint-and-test.yml
@@ -38,6 +38,8 @@ jobs:
         run: python -m pip install uv
       - name: venv
         run: uv venv .venv
+      - name: setuptools
+        run: uv pip install --upgrade setuptools
       - name: install requirements
         run: uv pip install -e .[dev]
       - name: run pytest (linux)

--- a/.github/workflows/Lint-and-test.yml
+++ b/.github/workflows/Lint-and-test.yml
@@ -36,6 +36,8 @@ jobs:
           python-version: ${{ matrix.version }}
       - name: install uv
         run: python -m pip install uv
+      - name: venv
+        run: uv venv .venv
       - name: install requirements
         run: uv pip install -e .[dev]
       - name: run pytest (linux)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ classifiers = [
 
 dependencies = [
   "bluesky",
+  "epicscorelibs>=7.0.7.99.1.2a1",
   "ophyd-async[ca] >= 0.8.0",
   "matplotlib",
   "lmfit",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,8 @@ classifiers = [
 
 dependencies = [
   "bluesky",
-  "epicscorelibs>=7.0.7.99.1.2a1",
-  "pvxslibs>=1.3.3a1",
+  "epicscorelibs>=7.0.3.99.2.0a1 ",
+  "pvxslibs>=0.3.0a1",
   "ophyd-async[ca] >= 0.8.0",
   "matplotlib",
   "lmfit",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 
 dependencies = [
   "bluesky",
-  "epicscorelibs>=7.0.3.99.2.0a1 ",
+  "epicscorelibs>=7.0.3.99.2.0a1",
   "pvxslibs>=0.3.0a1",
   "ophyd-async[ca] >= 0.8.0",
   "matplotlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ classifiers = [
 dependencies = [
   "bluesky",
   "epicscorelibs>=7.0.7.99.1.2a1",
+  "pvxslibs>=1.3.3a1",
   "ophyd-async[ca] >= 0.8.0",
   "matplotlib",
   "lmfit",


### PR DESCRIPTION
some notes for this: 

- https://docs.astral.sh/uv/pip/compatibility/#pre-release-compatibility : we had to add epicscorelibs and pvxslibs explicitly use their alpha versions
- `uv run pytest` was just weird and seemed to install a new version of numpy 