### PR TITLE
remove duplicate fields

### DIFF
--- a/src/ibex_bluesky_core/plans/__init__.py
+++ b/src/ibex_bluesky_core/plans/__init__.py
@@ -75,12 +75,6 @@ def _set_up_fields_and_icc(
         fields.append(dae.period_num.name)  # type: ignore
     elif save_run:
         fields.append(dae.controller.run_number.name)  # type: ignore
-    fields.extend(
-        [
-            dae.reducer.intensity.name,  # type: ignore
-            dae.reducer.intensity_stddev.name,  # type: ignore
-        ]
-    )
     icc = ISISCallbacks(
         y=dae.reducer.intensity.name,  # type: ignore
         yerr=dae.reducer.intensity_stddev.name,  # type: ignore


### PR DESCRIPTION
we specify them as `y` and `yerr` anyway, so they end up in a human-readable file header twice. No need to explicitly add them. 