### PR TITLE
Remove wait for CHANGED on a refl param redefine

### DIFF
--- a/src/ibex_bluesky_core/devices/reflectometry/__init__.py
+++ b/src/ibex_bluesky_core/devices/reflectometry/__init__.py
@@ -86,10 +86,10 @@ class ReflParameterRedefine(StandardReadable):
         """
         logger.info("setting %s to %s", self.define_pos_sp.source, value)
         await self.define_pos_sp.set(value, wait=True, timeout=None)
-        logger.info("waiting for 100ms for redefine to finish")
+        logger.info("waiting for 1s for redefine to finish")
         # The Reflectometry server has a CHANGED PV for a redefine, but it doesn't actually
         # give a monitor update, so just wait an arbitrary length of time for it to be done.
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(1.0)
 
 
 def refl_parameter(name: str, changing_timeout_s: float = 60.0) -> ReflParameter:

--- a/src/ibex_bluesky_core/devices/reflectometry/__init__.py
+++ b/src/ibex_bluesky_core/devices/reflectometry/__init__.py
@@ -65,18 +65,15 @@ class ReflParameter(StandardReadable):
 class ReflParameterRedefine(StandardReadable):
     """Utility device for redefining a reflectometry server parameter."""
 
-    def __init__(self, prefix: str, name: str, changed_timeout_s: float = 5.0) -> None:
+    def __init__(self, prefix: str, name: str) -> None:
         """Reflectometry server parameter redefinition.
 
         Args:
             prefix: the reflectometry parameter full address.
             name: the name of the parameter redefinition.
-            changed_timeout_s: seconds to wait for the CHANGED signal to go True after a set.
 
         """
-        self.changed: SignalR[bool] = epics_signal_r(bool, f"{prefix}DEFINE_POS_CHANGED")
         self.define_pos_sp = epics_signal_w(float, f"{prefix}DEFINE_POS_SP")
-        self.changed_timeout = changed_timeout_s
         super().__init__(name)
 
     @AsyncStatus.wrap
@@ -89,12 +86,10 @@ class ReflParameterRedefine(StandardReadable):
         """
         logger.info("setting %s to %s", self.define_pos_sp.source, value)
         await self.define_pos_sp.set(value, wait=True, timeout=None)
-        logger.info("waiting for %s", self.changed.source)
+        logger.info("waiting for 100ms for redefine to finish")
+        # The Reflectometry server has a CHANGED PV for a redefine, but it doesn't actually
+        # give a monitor update, so just wait an arbitrary length of time for it to be done.
         await asyncio.sleep(0.1)
-        async for chg in observe_value(self.changed, done_timeout=self.changed_timeout):
-            logger.debug("%s: %s", self.changed.source, chg)
-            if chg:
-                break
 
 
 def refl_parameter(name: str, changing_timeout_s: float = 60.0) -> ReflParameter:

--- a/tests/devices/test_reflectometry.py
+++ b/tests/devices/test_reflectometry.py
@@ -9,7 +9,6 @@ from ophyd_async.testing import callback_on_mock_put, get_mock_put, set_mock_val
 
 from ibex_bluesky_core.devices.reflectometry import (
     ReflParameter,
-    ReflParameterRedefine,
     refl_parameter,
 )
 
@@ -24,7 +23,7 @@ def test_refl_parameter_wrapper_returns_refl_parameter():
     assert param.readback.source == f"ca://{prefix}REFL_01:PARAM:{name}"
 
 
-def test_set_waits_for_changed_on_reflectometry_parameter(RE):
+def test_set_waits_for_changing_on_reflectometry_parameter(RE):
     param = ReflParameter(prefix="UNITTEST:", name="S1VG", changing_timeout_s=0.01)
     RE(ensure_connected(param, mock=True))
     initial = 123.0
@@ -42,29 +41,6 @@ async def test_times_out_if_changing_never_finishes_on_reflectometry_parameter(R
     initial = 123.0
     set_mock_value(param.setpoint, initial)
     set_mock_value(param.changing, True)
-    new_value = 456.0
-    with pytest.raises(asyncio.TimeoutError):
-        await param.set(new_value)
-
-
-def test_set_waits_for_changed_on_reflectometry_parameter_redefine(RE):
-    param = ReflParameterRedefine(prefix="UNITTEST:S1VG", name="redefine", changed_timeout_s=0.01)
-    RE(ensure_connected(param, mock=True))
-    initial = 123.0
-    set_mock_value(param.define_pos_sp, initial)
-    set_mock_value(param.changed, False)
-    callback_on_mock_put(param.define_pos_sp, lambda *a, **k: set_mock_value(param.changed, True))
-    new_value = 456.0
-    RE(bps.mv(param, new_value))
-    get_mock_put(param.define_pos_sp).assert_called_once_with(new_value, wait=True)
-
-
-async def test_times_out_if_changed_never_finishes_on_reflectometery_parameter_redefine(RE):
-    param = ReflParameterRedefine(prefix="UNITTEST:S1VG", name="redefine", changed_timeout_s=0.01)
-    RE(ensure_connected(param, mock=True))
-    initial = 123.0
-    set_mock_value(param.define_pos_sp, initial)
-    set_mock_value(param.changed, False)
     new_value = 456.0
     with pytest.raises(asyncio.TimeoutError):
         await param.set(new_value)

--- a/tests/test_plan_stubs.py
+++ b/tests/test_plan_stubs.py
@@ -8,7 +8,7 @@ import pytest
 from bluesky.utils import Msg
 from ophyd_async.epics.motor import UseSetMode
 from ophyd_async.plan_stubs import ensure_connected
-from ophyd_async.testing import callback_on_mock_put, get_mock_put, set_mock_value
+from ophyd_async.testing import get_mock_put
 
 from ibex_bluesky_core.devices.block import BlockMot
 from ibex_bluesky_core.devices.reflectometry import ReflParameter
@@ -152,10 +152,6 @@ def test_redefine_motor(RE):
 async def test_redefine_refl_parameter(RE):
     param = ReflParameter(prefix="", name="some_refl_parameter", changing_timeout_s=60)
     await param.connect(mock=True)
-
-    callback_on_mock_put(
-        param.redefine.define_pos_sp, lambda *a, **k: set_mock_value(param.redefine.changed, True)
-    )
 
     RE(redefine_refl_parameter(param, 42.0))
 


### PR DESCRIPTION
found when we wrote the initial top level plan on polref - the refl server helpfully never updates a monitor so CHANGED never actually gets set... 