### PR TITLE
Remove clear_checkpoint from call_sync

### DIFF
--- a/doc/plan_stubs/external_code.md
+++ b/doc/plan_stubs/external_code.md
@@ -57,7 +57,6 @@ def good_plan():
     # Note use of g.some_function, rather than g.some_function() - i.e. a function reference
     # We can also access the returned value from the call.
     return_value = yield from call_sync(g.some_function, 123, keyword_argument=456)
-    yield from bps.checkpoint()
     yield from bps.close_run()
 ```
 
@@ -65,13 +64,3 @@ It is strongly recommended that any functions run in this way are "fast" (i.e. l
 In particular, avoid doing arbitrarily-long waits - for example, waiting for detector data
 or sample environment. For these long-running tasks, seek to implement at least the long-running parts using 
 native bluesky mechanisms.
-
-```{note}
-`bps.checkpoint()` above instructs bluesky that this is a safe point from which to resume a plan. 
-`call_sync` always clears an active checkpoint first, as the code it runs may have arbitrary external
-side effects.
-
-If a plan is interrupted with no checkpoint active, it cannot be resumed later (it effectively forces
-the plan to abort rather than pause). You will see `bluesky.utils.FailedPause` as part of the traceback
-on ctrl-c, if this is the case.
-```

--- a/src/ibex_bluesky_core/plan_stubs/__init__.py
+++ b/src/ibex_bluesky_core/plan_stubs/__init__.py
@@ -37,19 +37,12 @@ def call_sync(func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> Genera
 
     - Blocking the whole event loop
     - Breaking keyboard interrupt handling
-    - Not clearing the active checkpoint
 
     It does not necessarily guard against all possible cases, and as such it is *recommended* to
     use native bluesky functionality wherever possible in preference to this plan stub. This should
     be seen as an escape-hatch.
 
     The wrapped function will be run in a new thread.
-
-    This plan stub will clear any active checkpoints before running the external code, because
-    in general the external code is not safe to re-run later once it has started (e.g. it may have
-    done relative sets, or may have started some external process). This means that if a plan is
-    interrupted at any point between a call_sync and the next checkpoint, the plan cannot be
-    resumed - in this case bluesky.utils.FailedPause will appear in the ctrl-c stack trace.
 
     Args:
         func: A callable to run.
@@ -60,7 +53,6 @@ def call_sync(func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> Genera
         The return value of the wrapped function
 
     """
-    yield from bps.clear_checkpoint()
     return cast(T, (yield Msg(CALL_SYNC_MSG_KEY, func, *args, **kwargs)))
 
 


### PR DESCRIPTION
Closes https://github.com/ISISComputingGroup/ibex_bluesky_core/issues/137

# Release notes

> The `call_sync` plan stub no longer clears an active checkpoint. This means that plans using `call_sync` which are stopped by a keyboard interrupt will now be resumable.