### PR TITLE
Reword adrs

### DIFF
--- a/doc/architectural_decisions/001-repo-structure.md
+++ b/doc/architectural_decisions/001-repo-structure.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Current
+Current, partially superseded by [ADR 006](006-where-to-put-code.md)
 
 ## Context
 
@@ -15,14 +15,14 @@ Tom & Kathryn
 
 ## Decision
 
-We will create a `core` repository, and publish it on PyPI.
+We will create a `core` repository, called `ibex_bluesky_core`, and publish it on PyPI.
 
 This repository will provide core building blocks, including plan stubs,
 devices, and utilities which are generic and expected to be useful across
 different science groups.
 
-Beamline or technique specific repositories will then depend on the `core`
-repository via PyPI.
+~~Beamline or technique specific repositories will then depend on the `core` repository via PyPI.~~
+Superseded by [ADR 006](006-where-to-put-code.md).
 
 The core repository will not depend on `genie_python`, so that other groups
 at RAL can use this repository. The genie python *distribution* may in future

--- a/doc/architectural_decisions/001-repo-structure.md
+++ b/doc/architectural_decisions/001-repo-structure.md
@@ -1,8 +1,8 @@
-# Repository structure
+# 1. Repository structure
 
 ## Status
 
-Current, partially superseded by [ADR 006](006-where-to-put-code.md)
+Current, partially superseded by [ADR 6](006-where-to-put-code.md)
 
 ## Context
 
@@ -22,18 +22,18 @@ devices, and utilities which are generic and expected to be useful across
 different science groups.
 
 ~~Beamline or technique specific repositories will then depend on the `core` repository via PyPI.~~
-Superseded by [ADR 006](006-where-to-put-code.md).
+Superseded by [ADR 6](006-where-to-put-code.md).
 
-The core repository will not depend on `genie_python`, so that other groups
-at RAL can use this repository. The genie python *distribution* may in future
-depend on this repository.
+The core repository will not depend on [`genie_python`](https://github.com/isiscomputinggroup/genie), so that other
+groups at RAL can use this repository. The [uktena](https://github.com/isiscomputinggroup/uktena) python *distribution* 
+depends on this repository.
 
-This `core` repository is analogous to a similar repo, `dodal`, being used at
-Diamond.
+This `ibex_bluesky_core` repository is analogous to a similar repo, 
+[dodal](https://github.com/diamondlightsource/dodal), being used at Diamond Light Source.
 
 ## Consequences
 
-- We will have some bluesky code across multiple repositories.
+- We will have some bluesky code across multiple locations.
 - Other groups should be able to:
   - Pull this code easily from PyPI
   - Contribute to the code without depending on all of IBEX's infrastructure

--- a/doc/architectural_decisions/001-repo-structure.md
+++ b/doc/architectural_decisions/001-repo-structure.md
@@ -26,10 +26,11 @@ Superseded by [ADR 6](006-where-to-put-code.md).
 
 The core repository will not depend on [`genie_python`](https://github.com/isiscomputinggroup/genie), so that other
 groups at RAL can use this repository. The [uktena](https://github.com/isiscomputinggroup/uktena) python *distribution* 
-depends on this repository.
+includes this repository as one of its included libraries.
 
 This `ibex_bluesky_core` repository is analogous to a similar repo, 
-[dodal](https://github.com/diamondlightsource/dodal), being used at Diamond Light Source.
+[dodal](https://github.com/diamondlightsource/dodal), being used at Diamond Light Source, or
+[apstools](https://github.com/BCDA-APS/apstools), being used at the Advanced Photon Source.
 
 ## Consequences
 

--- a/doc/architectural_decisions/002-use-ophyd-async.md
+++ b/doc/architectural_decisions/002-use-ophyd-async.md
@@ -1,4 +1,4 @@
-# Use `ophyd-async`
+# 2. Use `ophyd-async`
 
 ## Status
 
@@ -9,13 +9,18 @@ Current
 We need to decide whether to use `ophyd` or `ophyd-async` as our bluesky
 device abstraction layer.
 
+| | Docs                                     | Source | PyPi |
+| - |-| - | - |
+| ophyd | [Docs](https://blueskyproject.io/ophyd/) | [Source](https://github.com/bluesky/ophyd) | [PyPi](https://pypi.org/project/ophyd/) |
+| ophyd-async | [Docs](https://blueskyproject.io/ophyd-async/) | [Source](https://github.com/bluesky/ophyd-async) | [PyPi](https://pypi.org/project/ophyd-async/) |
+
 `ophyd` has been the default device abstraction layer for bluesky EPICS devices for
 some time.
 
 `ophyd-async` is a newer (and therefore less mature) device abstraction layer, 
 with similar concepts to `ophyd`. It has been implemented primarily by DLS.
 
-The *primary* differences are:
+The *primary* differences which are relevant for ISIS are:
 - In `ophyd-async` many functions are implemented as `asyncio` coroutines.
 - `ophyd-async` has better support for non-channel-access backends (notably, PVA)
 - Reduction in boilerplate

--- a/doc/architectural_decisions/003-run-in-process.md
+++ b/doc/architectural_decisions/003-run-in-process.md
@@ -1,4 +1,4 @@
-# Run in-process
+# 3. Run in-process
 
 ## Status
 

--- a/doc/architectural_decisions/004-use-scipp.md
+++ b/doc/architectural_decisions/004-use-scipp.md
@@ -1,4 +1,4 @@
-# Use `scipp`
+# 4. Use `scipp`
 
 ## Status
 

--- a/doc/architectural_decisions/005-variance-addition.md
+++ b/doc/architectural_decisions/005-variance-addition.md
@@ -1,4 +1,4 @@
-# Variance addition to counts data
+# 5. Variance addition to counts data
 
 ## Status
 
@@ -54,5 +54,5 @@ The consensus was to go with Option D.
 
 - Option A will cause real-life scans to crash in low counts regions.
 - Option B involves `NaN`s, which have many surprising floating-point characteristics and are highly likely to be a source of future bugs.
-- Option D was preferred to option C by scientists present.
+- Option D was preferred to option C by scientists present, because it is continuous.
 - Option E causes surprising results and/or crashes downstream, for example fitting may consider points with zero uncertainty to have "infinite" weight, therefore effectively disregarding all other data.

--- a/doc/architectural_decisions/005-variance-addition.md
+++ b/doc/architectural_decisions/005-variance-addition.md
@@ -6,19 +6,37 @@ Current
 
 ## Context
 
-For counts data, the uncertainty on counts is typically defined by poisson counting statistics, i.e. the standard deviation on `N` counts is `sqrt(N)`.
+For counts data, the uncertainty on counts is typically defined by poisson counting statistics, i.e. the standard
+deviation on `N` counts is `sqrt(N)`.
 
-This can be problematic in cases where zero counts have been collected, as the standard deviation will then be zero, which will subsequently lead to "infinite" point weightings in downstream fitting routines for example.
+This can be problematic in cases where zero counts have been collected, as the standard deviation will then be zero,
+which will subsequently lead to "infinite" point weightings in downstream fitting routines for example.
 
 A number of possible approaches were considered:
 
-| Option | Description |
-| --- | --- |
-| A | Reject data with zero counts, i.e. explicitly throw an exception if any data with zero counts is seen as part of a scan. |
-| B | Use a standard deviation of `NaN` for points with zero counts. |
-| C | Define the standard deviation of `N` counts as `1` if counts are zero, otherwise `sqrt(N)`. This is one of the approaches available in mantid for example. |
-| D | Define the standard deviation of `N` counts as `sqrt(N+0.5)` unconditionally - on the basis that "half a count" is smaller than the smallest possible actual measurement which can be taken. |
-| E | No special handling, calculate std. dev. as `sqrt(N)`. |
+### Option A
+
+Reject data with zero counts, i.e. explicitly throw an exception if any data with zero counts is seen as part of a scan.
+
+### Option B
+
+Use a standard deviation of `NaN` for points with zero counts.
+
+### Option C
+
+Define the standard deviation of `N` counts as `1` if counts are zero, otherwise `sqrt(N)`. This is one of the
+approaches [available in mantid](https://github.com/mantidproject/mantid/blob/bbbb86edc2c3fa554499770463aa25c2b46984e5/docs/source/algorithms/SetUncertainties-v1.rst#L16) for example.
+
+### Option D
+
+Define the standard deviation of `N` counts as `sqrt(N+0.5)` unconditionally - on the basis that "half a count" is 
+smaller than the smallest possible actual measurement which can be taken.
+
+### Option E
+
+No special handling, calculate std. dev. as `sqrt(N)`.
+
+---
 
 For clarity, the following table shows the value and associated uncertainty for each option:
 
@@ -53,6 +71,8 @@ The consensus was to go with Option D.
 ## Justification
 
 - Option A will cause real-life scans to crash in low counts regions.
-- Option B involves `NaN`s, which have many surprising floating-point characteristics and are highly likely to be a source of future bugs.
+- Option B involves `NaN`s, which have many surprising floating-point characteristics and are highly likely to be a
+source of future bugs.
 - Option D was preferred to option C by scientists present, because it is continuous.
-- Option E causes surprising results and/or crashes downstream, for example fitting may consider points with zero uncertainty to have "infinite" weight, therefore effectively disregarding all other data.
+- Option E causes surprising results and/or crashes downstream, for example fitting may consider points with zero
+uncertainty to have "infinite" weight, therefore effectively disregarding all other data.

--- a/doc/architectural_decisions/006-where-to-put-code.md
+++ b/doc/architectural_decisions/006-where-to-put-code.md
@@ -1,4 +1,4 @@
-# Where to put code
+# 6. Where to put code
 
 ## Status
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -29,7 +29,7 @@ nitpick_ignore_regex = [
     ("py:obj", r"^.*\.T.*_co$"),
 ]
 
-myst_enable_extensions = ["dollarmath"]
+myst_enable_extensions = ["dollarmath", "strikethrough"]
 
 extensions = [
     "myst_parser",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -30,6 +30,7 @@ nitpick_ignore_regex = [
 ]
 
 myst_enable_extensions = ["dollarmath", "strikethrough"]
+suppress_warnings = ["myst.strikethrough"]
 
 extensions = [
     "myst_parser",


### PR DESCRIPTION
Reword/clarify a couple of ADRs.

**No substantive change to the decision(s) they document**, just:
- Clarifying that parts of ADR 1 are now superseded by ADR 6
- Expanding/clarifying the text of ADR 4 as I got some feedback from another group it wasn't entirely clear
- Various minor edits, adding links etc for clarity