### PR TITLE
Add version as metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,5 @@ _build/
 
 ibex-bluesky-core-pytest-logs
 ibex-bluesky-core-pytest-output
+
+src/ibex_bluesky_core/version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ reportUntypedClassDecorator = true
 reportUntypedFunctionDecorator = true
 
 [tool.setuptools_scm]
+version_file = "src/ibex_bluesky_core/version.py"
 
 [tool.build_sphinx]
 

--- a/src/ibex_bluesky_core/callbacks/__init__.py
+++ b/src/ibex_bluesky_core/callbacks/__init__.py
@@ -28,7 +28,7 @@ from ibex_bluesky_core.callbacks.plotting import LivePlot
 
 logger = logging.getLogger(__name__)
 
-# ruff: noqa: PLR0913, PLR0912, PLR0917
+# ruff: noqa: PLR0913
 
 
 class ISISCallbacks:

--- a/src/ibex_bluesky_core/run_engine/__init__.py
+++ b/src/ibex_bluesky_core/run_engine/__init__.py
@@ -19,6 +19,7 @@ __all__ = ["get_run_engine"]
 
 from ibex_bluesky_core.plan_stubs import CALL_QT_AWARE_MSG_KEY, CALL_SYNC_MSG_KEY
 from ibex_bluesky_core.run_engine._msg_handlers import call_qt_aware_handler, call_sync_handler
+from ibex_bluesky_core.version import version
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +94,8 @@ def get_run_engine() -> RunEngine:
         during_task=dt,
         call_returns_result=True,  # Will be default in a future bluesky version.
     )
+
+    RE.md["versions"]["ibex_bluesky_core"] = version
 
     log_callback = DocLoggingCallback()
     RE.subscribe(log_callback)

--- a/tests/test_run_engine.py
+++ b/tests/test_run_engine.py
@@ -11,6 +11,7 @@ from bluesky.run_engine import RunEngineResult
 from bluesky.utils import Msg, RequestAbort, RunEngineInterrupted
 
 from ibex_bluesky_core.run_engine import _DuringTask, get_run_engine
+from ibex_bluesky_core.version import version
 
 
 def test_run_engine_is_singleton():
@@ -82,3 +83,7 @@ def test_during_task_does_wait_with_small_timeout():
 
     event.wait.assert_called_with(0.1)
     assert event.wait.call_count == 2
+
+
+def test_runengine_has_version_number_as_metadata(RE):
+    assert RE.md["versions"]["ibex_bluesky_core"] == version


### PR DESCRIPTION
Add the version of `ibex_bluesky_core` as metadata in the re for traceability