### PR TITLE
Optometrise

### DIFF
--- a/src/ibex_bluesky_core/callbacks/__init__.py
+++ b/src/ibex_bluesky_core/callbacks/__init__.py
@@ -68,7 +68,7 @@ class ISISCallbacks:
         live_fit_logger_postfix: str = "",
         human_readable_file_postfix: str = "",
         live_fit_update_every: int | None = 1,
-        live_plot_show_every_event: bool = True,
+        live_plot_update_on_every_event: bool = True,
     ) -> None:
         """A collection of ISIS standard callbacks for use within plans.
 
@@ -128,7 +128,7 @@ class ISISCallbacks:
             live_fit_logger_postfix: the postfix to add to live fit logger.
             human_readable_file_postfix: optional postfix to add to human-readable file logger.
             live_fit_update_every: How often, in points, to recompute the fit. If None, do not compute until the end.
-            live_plot_show_every_event: whether to show the live plot on every event, or just at the end.
+            live_plot_update_on_every_event: whether to show the live plot on every event, or just at the end.
         """  # noqa
         self._subs = []
         self._peak_stats = None
@@ -174,6 +174,7 @@ class ISISCallbacks:
             if is_matplotlib_backend_qt():
                 done_event = threading.Event()
 
+                # Note: not really a callback, this never gets attached to the runengine
                 class _Cb(QtAwareCallback):
                     def start(self, doc: RunStart) -> None:
                         nonlocal fig, ax
@@ -226,7 +227,7 @@ class ISISCallbacks:
                     linestyle="none",
                     ax=ax,
                     yerr=yerr,
-                    show_every_event=live_plot_show_every_event,
+                    update_on_every_event=live_plot_update_on_every_event,
                 )
             )
 

--- a/src/ibex_bluesky_core/callbacks/__init__.py
+++ b/src/ibex_bluesky_core/callbacks/__init__.py
@@ -24,6 +24,7 @@ from ibex_bluesky_core.callbacks._fitting import LiveFit, LiveFitLogger
 from ibex_bluesky_core.callbacks._plotting import LivePlot, show_plot
 from ibex_bluesky_core.callbacks._utils import get_default_output_path
 from ibex_bluesky_core.fitting import FitMethod
+from ibex_bluesky_core.utils import is_matplotlib_backend_qt
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +46,7 @@ __all__ = [
 class ISISCallbacks:
     """ISIS standard callbacks for use within plans."""
 
-    def __init__(
+    def __init__(  # noqa: PLR0912
         self,
         *,
         x: str,
@@ -66,6 +67,8 @@ class ISISCallbacks:
         live_fit_logger_output_dir: str | PathLike[str] | None = None,
         live_fit_logger_postfix: str = "",
         human_readable_file_postfix: str = "",
+        live_fit_update_every: int | None = 1,
+        live_plot_show_every_event: bool = True,
     ) -> None:
         """A collection of ISIS standard callbacks for use within plans.
 
@@ -124,6 +127,8 @@ class ISISCallbacks:
             live_fit_logger_output_dir: the output directory for live fit logger.
             live_fit_logger_postfix: the postfix to add to live fit logger.
             human_readable_file_postfix: optional postfix to add to human-readable file logger.
+            live_fit_update_every: How often to recompute the fit. If None, do not compute until the end.
+            live_plot_show_every_event: whether to show the live plot on every event, or just at the end.
         """  # noqa
         self._subs = []
         self._peak_stats = None
@@ -164,31 +169,41 @@ class ISISCallbacks:
 
         if (add_plot_cb or show_fit_on_plot) and not ax:
             logger.debug("No axis provided, creating a new one")
-            fig, ax, exc, result = None, None, None, None
-            done_event = threading.Event()
+            fig, ax = None, None
 
-            class _Cb(QtAwareCallback):
-                def start(self, doc: RunStart) -> None:
-                    nonlocal result, exc, fig, ax
-                    try:
-                        plt.close("all")
-                        fig, ax = plt.subplots()
-                    finally:
-                        done_event.set()
+            if is_matplotlib_backend_qt():
+                done_event = threading.Event()
 
-            cb = _Cb()
-            cb("start", {"time": 0, "uid": ""})
-            done_event.wait(10.0)
+                class _Cb(QtAwareCallback):
+                    def start(self, doc: RunStart) -> None:
+                        nonlocal fig, ax
+                        try:
+                            plt.close("all")
+                            fig, ax = plt.subplots()
+                        finally:
+                            done_event.set()
+
+                cb = _Cb()
+                cb("start", {"time": 0, "uid": ""})
+                done_event.wait(10.0)
+            else:
+                plt.close("all")
+                fig, ax = plt.subplots()
 
         if fit is not None:
-            self._live_fit = LiveFit(fit, y=y, x=x, yerr=yerr)
+            self._live_fit = LiveFit(fit, y=y, x=x, yerr=yerr, update_every=live_fit_update_every)
 
-            # Ideally this would append either livefitplot or livefit, not both, but there's a
-            # race condition if using the Qt backend where a fit result can be returned before
-            # the QtAwareCallback has had a chance to process it.
-            self._subs.append(self._live_fit)
             if show_fit_on_plot:
+                if is_matplotlib_backend_qt():
+                    # Ideally this would append either livefitplot
+                    # or livefit, not both, but there's a
+                    # race condition if using the Qt backend
+                    # where a fit result can be returned before
+                    # the QtAwareCallback has had a chance to process it.
+                    self._subs.append(self._live_fit)
                 self._subs.append(LiveFitPlot(livefit=self._live_fit, ax=ax))
+            else:
+                self._subs.append(self._live_fit)
 
             if add_live_fit_logger:
                 self._subs.append(
@@ -211,6 +226,7 @@ class ISISCallbacks:
                     linestyle="none",
                     ax=ax,
                     yerr=yerr,
+                    show_every_event=live_plot_show_every_event,
                 )
             )
 

--- a/src/ibex_bluesky_core/callbacks/__init__.py
+++ b/src/ibex_bluesky_core/callbacks/__init__.py
@@ -127,7 +127,7 @@ class ISISCallbacks:
             live_fit_logger_output_dir: the output directory for live fit logger.
             live_fit_logger_postfix: the postfix to add to live fit logger.
             human_readable_file_postfix: optional postfix to add to human-readable file logger.
-            live_fit_update_every: How often to recompute the fit. If None, do not compute until the end.
+            live_fit_update_every: How often, in points, to recompute the fit. If None, do not compute until the end.
             live_plot_show_every_event: whether to show the live plot on every event, or just at the end.
         """  # noqa
         self._subs = []

--- a/src/ibex_bluesky_core/callbacks/_fitting.py
+++ b/src/ibex_bluesky_core/callbacks/_fitting.py
@@ -35,7 +35,13 @@ class LiveFit(_DefaultLiveFit):
     """LiveFit, customized for IBEX."""
 
     def __init__(
-        self, method: FitMethod, y: str, x: str, *, update_every: int = 1, yerr: str | None = None
+        self,
+        method: FitMethod,
+        y: str,
+        x: str,
+        *,
+        update_every: int | None = 1,
+        yerr: str | None = None,
     ) -> None:
         """Call Bluesky LiveFit with assumption that there is only one independant variable.
 
@@ -43,7 +49,7 @@ class LiveFit(_DefaultLiveFit):
             method (FitMethod): The FitMethod (Model & Guess) to use when fitting.
             y (str): The name of the dependant variable.
             x (str): The name of the independant variable.
-            update_every (int, optional): How often to update the fit. (seconds)
+            update_every (int, optional): How often to update the fit.
             yerr (str or None, optional): Name of field in the Event document
                 that provides standard deviation for each Y value. None meaning
                 do not use uncertainties in fit.
@@ -54,7 +60,10 @@ class LiveFit(_DefaultLiveFit):
         self.weight_data = []
 
         super().__init__(
-            model=method.model, y=y, independent_vars={"x": x}, update_every=update_every
+            model=method.model,
+            y=y,
+            independent_vars={"x": x},
+            update_every=update_every,  # type: ignore
         )
 
     def event(self, doc: Event) -> None:
@@ -110,7 +119,6 @@ class LiveFit(_DefaultLiveFit):
             self.result = self.model.fit(
                 self.ydata, weights=None if self.yerr is None else self.weight_data, **kwargs
             )
-            self.__stale = False
 
 
 class LiveFitLogger(CallbackBase):

--- a/src/ibex_bluesky_core/callbacks/_fitting.py
+++ b/src/ibex_bluesky_core/callbacks/_fitting.py
@@ -49,7 +49,7 @@ class LiveFit(_DefaultLiveFit):
             method (FitMethod): The FitMethod (Model & Guess) to use when fitting.
             y (str): The name of the dependant variable.
             x (str): The name of the independant variable.
-            update_every (int, optional): How often to update the fit.
+            update_every (int, optional): How often, in points, to update the fit.
             yerr (str or None, optional): Name of field in the Event document
                 that provides standard deviation for each Y value. None meaning
                 do not use uncertainties in fit.

--- a/src/ibex_bluesky_core/callbacks/_plotting.py
+++ b/src/ibex_bluesky_core/callbacks/_plotting.py
@@ -36,7 +36,7 @@ class LivePlot(_DefaultLivePlot):
         x: str | None = None,
         yerr: str | None = None,
         *args: Any,  # noqa: ANN401
-        show_every_event: bool = True,
+        update_on_every_event: bool = True,
         **kwargs: Any,  # noqa: ANN401
     ) -> None:
         """Initialise LivePlot.
@@ -47,11 +47,12 @@ class LivePlot(_DefaultLivePlot):
             yerr (str or None, optional): Name of uncertainties signal.
                 Providing None means do not plot uncertainties.
             *args: As per mpl_plotting.py
-            show_every_event (bool, optional): Whether to show plot every event, or just at the end.
+            update_on_every_event (bool, optional): Whether to update plot every event,
+                or just at the end.
             **kwargs: As per mpl_plotting.py
 
         """
-        self.show_every_event = show_every_event
+        self.update_on_every_event = update_on_every_event
         super().__init__(y=y, x=x, *args, **kwargs)  # noqa: B026
         if yerr is not None:
             self.yerr, *_others = get_obj_fields([yerr])
@@ -66,12 +67,12 @@ class LivePlot(_DefaultLivePlot):
         new_yerr = None if self.yerr is None else doc["data"][self.yerr]
         self.update_yerr(new_yerr)
         super().event(doc)
-        if self.show_every_event:
+        if self.update_on_every_event:
             show_plot()
 
     def update_plot(self, force: bool = False) -> None:
         """Create error bars if needed, then update plot."""
-        if self.show_every_event or force:
+        if self.update_on_every_event or force:
             if self.yerr is not None:
                 if self._mpl_errorbar_container is not None:
                     # Remove old error bars before drawing new ones
@@ -94,6 +95,6 @@ class LivePlot(_DefaultLivePlot):
     def stop(self, doc: RunStop) -> None:
         """Process an start document (delegate to superclass, then show the plot)."""
         super().stop(doc)
-        if not self.show_every_event:
+        if not self.update_on_every_event:
             self.update_plot(force=True)
             show_plot()

--- a/src/ibex_bluesky_core/plans/reflectometry/_autoalign.py
+++ b/src/ibex_bluesky_core/plans/reflectometry/_autoalign.py
@@ -7,6 +7,8 @@ import bluesky.plan_stubs as bps
 from bluesky.protocols import NamedMovable
 from bluesky.utils import Msg
 from lmfit.model import ModelResult
+from ophyd_async.core import Device
+from ophyd_async.plan_stubs import ensure_connected
 
 from ibex_bluesky_core.callbacks import ISISCallbacks
 from ibex_bluesky_core.devices.simpledae import SimpleDae
@@ -206,6 +208,8 @@ def optimise_axis_against_intensity(  # noqa: PLR0913
         Instance of :obj:`ibex_bluesky_core.callbacks.ISISCallbacks`.
 
     """
+    assert isinstance(alignment_param, Device)
+    yield from ensure_connected(dae, alignment_param)
     problem_found_plan = problem_found_plan or bps.null
 
     logger.info(

--- a/src/ibex_bluesky_core/plans/reflectometry/_det_map_align.py
+++ b/src/ibex_bluesky_core/plans/reflectometry/_det_map_align.py
@@ -88,7 +88,7 @@ def _angle_scan_callback_and_fit(
         live_fit_logger_postfix="_angle",
         human_readable_file_postfix="_angle",
         live_fit_update_every=len(angle_map) - 1,
-        live_plot_show_every_event=False,
+        live_plot_update_on_every_event=False,
     )
     for cb in angle_scan_callbacks.subs:
         angle_scan_ld.subscribe(cb)

--- a/src/ibex_bluesky_core/plans/reflectometry/_det_map_align.py
+++ b/src/ibex_bluesky_core/plans/reflectometry/_det_map_align.py
@@ -87,6 +87,8 @@ def _angle_scan_callback_and_fit(
         ax=ax,
         live_fit_logger_postfix="_angle",
         human_readable_file_postfix="_angle",
+        live_fit_update_every=len(angle_map) - 1,
+        live_plot_show_every_event=False,
     )
     for cb in angle_scan_callbacks.subs:
         angle_scan_ld.subscribe(cb)
@@ -134,6 +136,7 @@ def angle_scan_plan(
     yield from ensure_connected(dae)
 
     yield from call_qt_aware(plt.close, "all")
+    yield from call_qt_aware(plt.show)
     _, ax = yield from call_qt_aware(plt.subplots)
 
     angle_cb, angle_fit = _angle_scan_callback_and_fit(reducer, angle_map, ax)

--- a/src/ibex_bluesky_core/run_engine/__init__.py
+++ b/src/ibex_bluesky_core/run_engine/__init__.py
@@ -7,7 +7,6 @@ from functools import cache
 from threading import Event
 
 import bluesky.preprocessors as bpp
-import matplotlib
 from bluesky.run_engine import RunEngine
 from bluesky.utils import DuringTask
 
@@ -19,6 +18,7 @@ __all__ = ["get_run_engine"]
 
 from ibex_bluesky_core.plan_stubs import CALL_QT_AWARE_MSG_KEY, CALL_SYNC_MSG_KEY
 from ibex_bluesky_core.run_engine._msg_handlers import call_qt_aware_handler, call_sync_handler
+from ibex_bluesky_core.utils import is_matplotlib_backend_qt
 from ibex_bluesky_core.version import version
 
 logger = logging.getLogger(__name__)
@@ -87,7 +87,7 @@ def get_run_engine() -> RunEngine:
     # See https://github.com/bluesky/bluesky/pull/1770 for details
     # We don't need to use our custom _DuringTask if matplotlib is
     # configured to use Qt.
-    dt = None if "qt" in matplotlib.get_backend() else _DuringTask()
+    dt = None if is_matplotlib_backend_qt() else _DuringTask()
 
     RE = RunEngine(
         loop=loop,

--- a/src/ibex_bluesky_core/run_engine/_msg_handlers.py
+++ b/src/ibex_bluesky_core/run_engine/_msg_handlers.py
@@ -100,7 +100,7 @@ async def call_sync_handler(msg: Msg) -> Any:  # noqa: ANN401
 
 
 async def call_qt_aware_handler(msg: Msg) -> Any:  # noqa: ANN401
-    """Handle ibex_bluesky_core.plan_stubs.call_sync."""
+    """Handle ibex_bluesky_core.plan_stubs.call_qt_aware."""
     func = msg.obj
     done_event = Event()
     result: Any = None
@@ -121,7 +121,6 @@ async def call_qt_aware_handler(msg: Msg) -> Any:  # noqa: ANN401
                     msg.kwargs,
                 )
                 result = func(*msg.args, **msg.kwargs)
-
                 import matplotlib.pyplot as plt  # noqa: PLC0415
 
                 plt.show()

--- a/src/ibex_bluesky_core/utils.py
+++ b/src/ibex_bluesky_core/utils.py
@@ -5,9 +5,15 @@ from __future__ import annotations
 import os
 from typing import Any, Protocol
 
+import matplotlib
 from bluesky.protocols import NamedMovable, Readable
 
-__all__ = ["NamedReadableAndMovable", "centred_pixel", "get_pv_prefix"]
+__all__ = ["NamedReadableAndMovable", "centred_pixel", "get_pv_prefix", "is_matplotlib_backend_qt"]
+
+
+def is_matplotlib_backend_qt() -> bool:
+    """Return True if matplotlib is using a qt backend."""
+    return "qt" in matplotlib.get_backend().lower()
 
 
 def centred_pixel(centre: int, pixel_range: int) -> list[int]:

--- a/tests/plans/test_reflectometry.py
+++ b/tests/plans/test_reflectometry.py
@@ -106,6 +106,10 @@ def test_found_problem_callback_is_called_if_problem(RE, simpledae, prefix, monk
     mock = MagicMock()
 
     with (
+        patch(
+            "ibex_bluesky_core.plans.reflectometry._autoalign.ensure_connected",
+            return_value=bps.null(),
+        ),
         patch("ibex_bluesky_core.devices.reflectometry.get_pv_prefix", return_value=prefix),
         patch("ibex_bluesky_core.plans.reflectometry._autoalign.scan", return_value=_fake_scan()),
         patch("ibex_bluesky_core.plans.reflectometry._autoalign.bps.mv", return_value=bps.null()),
@@ -250,6 +254,10 @@ def test_that_if_problem_found_and_type_1_then_re_scan(RE, prefix, simpledae, mo
             return "2"
 
     with (
+        patch(
+            "ibex_bluesky_core.plans.reflectometry._autoalign.ensure_connected",
+            return_value=bps.null(),
+        ),
         patch("ibex_bluesky_core.devices.reflectometry.get_pv_prefix", return_value=prefix),
         patch(
             "ibex_bluesky_core.plans.reflectometry._autoalign._check_parameter",
@@ -299,6 +307,10 @@ def test_that_if_problem_found_and_type_random_then_re_ask(RE, prefix, simpledae
             return "2"
 
     with (
+        patch(
+            "ibex_bluesky_core.plans.reflectometry._autoalign.ensure_connected",
+            return_value=bps.null(),
+        ),
         patch("ibex_bluesky_core.devices.reflectometry.get_pv_prefix", return_value=prefix),
         patch(
             "ibex_bluesky_core.plans.reflectometry._autoalign._check_parameter",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,7 +22,7 @@ def test_centred_pixel():
     assert centred_pixel(50, 3) == [47, 48, 49, 50, 51, 52, 53]
 
 
-@pytest.mark.parametrize("mpl_backend", ["qt", "something_else"])
+@pytest.mark.parametrize("mpl_backend", ["qt5Agg", "qt6Agg", "qtCairo", "something_else"])
 def test_is_matplotlib_backend_qt(mpl_backend: str):
     with patch("ibex_bluesky_core.utils.matplotlib.get_backend", return_value=mpl_backend):
-        assert is_matplotlib_backend_qt() == (mpl_backend == "qt")
+        assert is_matplotlib_backend_qt() == ("qt" in mpl_backend)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
-from ibex_bluesky_core.utils import centred_pixel, get_pv_prefix
+from ibex_bluesky_core.utils import centred_pixel, get_pv_prefix, is_matplotlib_backend_qt
 
 
 def test_get_pv_prefix():
@@ -20,3 +20,9 @@ def test_cannot_get_pv_prefix():
 
 def test_centred_pixel():
     assert centred_pixel(50, 3) == [47, 48, 49, 50, 51, 52, 53]
+
+
+@pytest.mark.parametrize("mpl_backend", ["qt", "something_else"])
+def test_is_matplotlib_backend_qt(mpl_backend: str):
+    with patch("ibex_bluesky_core.utils.matplotlib.get_backend", return_value=mpl_backend):
+        assert is_matplotlib_backend_qt() == (mpl_backend == "qt")


### PR DESCRIPTION
Closes https://github.com/ISISComputingGroup/ibex_bluesky_core/issues/153

- Adds an option to `LivePlot` to only plot at end
- Make refl detector-mapping stuff only fit at end
- Make sure we're not using [Schlemiel's algorithm](https://en.wikichip.org/wiki/schlemiel_the_painter%27s_algorithm) for error bar rendering
- Some Qt nonsense, because every PR needs some Qt nonsense

For a test case on my machine with ~1280 events, this reduces time spent on fitting/plotting callbacks from ~30s to ~1s