### PR TITLE
use blockrw for motor scan instead of block_mot

### DIFF
--- a/doc/plans/plans.md
+++ b/doc/plans/plans.md
@@ -67,7 +67,7 @@ Alternatively, we provide some very thin wrappers which construct the devices fo
 
 [`motor_adaptive_scan`](ibex_bluesky_core.plans.motor_scan)
 
-which wrap the above respectively. These take _names_ of blocks, rather than devices themselves, and construct a DAE and block device for you, using the global moving flag to determine if a motor has finished moving (in the same way as a `waitfor_move()`). This might be useful if you have a fairly standard DAE setup and just want to scan a block pointing at a motor such as a Sample Changer axis, but is obviously not as flexible or performant as the lower-level plans.
+which wrap the above respectively. These take _names_ of blocks, rather than devices themselves, and construct a DAE and block device for you, using the global moving flag to determine if a motor has finished moving (in the same way as a `waitfor_move()`). This might be useful if you have a fairly standard DAE setup and just want to scan a block pointing at a motor such as a Sample Changer axis, but is not as flexible or performant as the lower-level plans.
 
 for example if you just wanted to scan over a motor, wait for 400 frames, and perform a linear fit, you can just write this in the console: 
 

--- a/doc/plans/plans.md
+++ b/doc/plans/plans.md
@@ -67,7 +67,7 @@ Alternatively, we provide some very thin wrappers which construct the devices fo
 
 [`motor_adaptive_scan`](ibex_bluesky_core.plans.motor_scan)
 
-which wrap the above respectively. These take _names_ of blocks, rather than devices themselves, and construct a DAE and block device for you. This might be useful if you have a fairly standard DAE setup and just want to scan a block pointing at a motor such as a Sample Changer axis.
+which wrap the above respectively. These take _names_ of blocks, rather than devices themselves, and construct a DAE and block device for you, using the global moving flag to determine if a motor has finished moving (in the same way as a `waitfor_move()`). This might be useful if you have a fairly standard DAE setup and just want to scan a block pointing at a motor such as a Sample Changer axis, but is obviously not as flexible or performant as the lower-level plans.
 
 for example if you just wanted to scan over a motor, wait for 400 frames, and perform a linear fit, you can just write this in the console: 
 

--- a/src/ibex_bluesky_core/plans/__init__.py
+++ b/src/ibex_bluesky_core/plans/__init__.py
@@ -20,7 +20,7 @@ from ibex_bluesky_core.utils import NamedReadableAndMovable, centred_pixel, get_
 if TYPE_CHECKING:
     from ibex_bluesky_core.devices.simpledae import SimpleDae
 
-__all__ = ["adaptive_scan", "motor_adaptive_scan", "motor_scan", "polling_plan", "scan"]
+__all__ = ["BlockMot", "adaptive_scan", "motor_adaptive_scan", "motor_scan", "polling_plan", "scan"]
 
 
 def scan(  # noqa: PLR0913
@@ -169,9 +169,10 @@ def motor_scan(  # noqa: PLR0913
     save_run: bool = False,
     rel: bool = False,
 ) -> Generator[Msg, None, ISISCallbacks]:
-    """Wrap our scan() plan and create a block_mot and a DAE object.
+    """Wrap our scan() plan and create a block_rw and a DAE object.
 
-    This only works with blocks that are pointing at motor records.
+    This essentially uses the same mechanism as a waitfor_move by using the global "moving" flag
+    to determine if motors are still moving after starting a move.
     This is really just a wrapper around :func:`ibex_bluesky_core.plans.scan`
 
     Args:
@@ -192,7 +193,12 @@ def motor_scan(  # noqa: PLR0913
         an :obj:`ibex_bluesky_core.callbacks.ISISCallbacks` instance.
 
     """
-    block = BlockRw(float, prefix=get_pv_prefix(), block_name=block_name, write_config=BlockWriteConfig(use_global_moving_flag=True))
+    block = BlockRw(
+        float,
+        prefix=get_pv_prefix(),
+        block_name=block_name,
+        write_config=BlockWriteConfig(use_global_moving_flag=True),
+    )
     det_pixels = centred_pixel(det, pixel_range)
     dae = monitor_normalising_dae(
         det_pixels=det_pixels, frames=frames, periods=periods, save_run=save_run, monitor=mon
@@ -230,9 +236,10 @@ def motor_adaptive_scan(  # noqa: PLR0913
     save_run: bool = False,
     rel: bool = False,
 ) -> Generator[Msg, None, ISISCallbacks]:
-    """Wrap adaptive_scan() plan and create a block_mot and a DAE object.
+    """Wrap adaptive_scan() plan and create a block_rw and a DAE object.
 
-    This only works with blocks that are pointing at motor records.
+    This essentially uses the same mechanism as a waitfor_move by using the global "moving" flag
+    to determine if motors are still moving after starting a move.
     This is really just a wrapper around :func:`ibex_bluesky_core.plans.adaptive_scan`
 
     Args:
@@ -255,7 +262,12 @@ def motor_adaptive_scan(  # noqa: PLR0913
         an :obj:`ibex_bluesky_core.callbacks.ISISCallbacks` instance.
 
     """
-    block = BlockRw(float, prefix=get_pv_prefix(), block_name=block_name, write_config=BlockWriteConfig(use_global_moving_flag=True))
+    block = BlockRw(
+        float,
+        prefix=get_pv_prefix(),
+        block_name=block_name,
+        write_config=BlockWriteConfig(use_global_moving_flag=True),
+    )
     det_pixels = centred_pixel(det, pixel_range)
     dae = monitor_normalising_dae(
         det_pixels=det_pixels, frames=frames, periods=periods, save_run=save_run, monitor=mon

--- a/src/ibex_bluesky_core/plans/__init__.py
+++ b/src/ibex_bluesky_core/plans/__init__.py
@@ -12,15 +12,15 @@ from bluesky.utils import Msg
 from ophyd_async.plan_stubs import ensure_connected
 
 from ibex_bluesky_core.callbacks import ISISCallbacks
-from ibex_bluesky_core.devices.block import BlockMot, BlockRw, BlockWriteConfig
+from ibex_bluesky_core.devices.block import BlockWriteConfig, block_rw
 from ibex_bluesky_core.devices.simpledae import monitor_normalising_dae
 from ibex_bluesky_core.fitting import FitMethod
-from ibex_bluesky_core.utils import NamedReadableAndMovable, centred_pixel, get_pv_prefix
+from ibex_bluesky_core.utils import NamedReadableAndMovable, centred_pixel
 
 if TYPE_CHECKING:
     from ibex_bluesky_core.devices.simpledae import SimpleDae
 
-__all__ = ["BlockMot", "adaptive_scan", "motor_adaptive_scan", "motor_scan", "polling_plan", "scan"]
+__all__ = ["adaptive_scan", "motor_adaptive_scan", "motor_scan", "polling_plan", "scan"]
 
 
 def scan(  # noqa: PLR0913
@@ -193,9 +193,8 @@ def motor_scan(  # noqa: PLR0913
         an :obj:`ibex_bluesky_core.callbacks.ISISCallbacks` instance.
 
     """
-    block = BlockRw(
+    block = block_rw(
         float,
-        prefix=get_pv_prefix(),
         block_name=block_name,
         write_config=BlockWriteConfig(use_global_moving_flag=True),
     )
@@ -262,9 +261,8 @@ def motor_adaptive_scan(  # noqa: PLR0913
         an :obj:`ibex_bluesky_core.callbacks.ISISCallbacks` instance.
 
     """
-    block = BlockRw(
+    block = block_rw(
         float,
-        prefix=get_pv_prefix(),
         block_name=block_name,
         write_config=BlockWriteConfig(use_global_moving_flag=True),
     )

--- a/src/ibex_bluesky_core/plans/__init__.py
+++ b/src/ibex_bluesky_core/plans/__init__.py
@@ -12,7 +12,7 @@ from bluesky.utils import Msg
 from ophyd_async.plan_stubs import ensure_connected
 
 from ibex_bluesky_core.callbacks import ISISCallbacks
-from ibex_bluesky_core.devices.block import BlockMot
+from ibex_bluesky_core.devices.block import BlockMot, BlockRw, BlockWriteConfig
 from ibex_bluesky_core.devices.simpledae import monitor_normalising_dae
 from ibex_bluesky_core.fitting import FitMethod
 from ibex_bluesky_core.utils import NamedReadableAndMovable, centred_pixel, get_pv_prefix
@@ -192,7 +192,7 @@ def motor_scan(  # noqa: PLR0913
         an :obj:`ibex_bluesky_core.callbacks.ISISCallbacks` instance.
 
     """
-    block = BlockMot(prefix=get_pv_prefix(), block_name=block_name)
+    block = BlockRw(float, prefix=get_pv_prefix(), block_name=block_name, write_config=BlockWriteConfig(use_global_moving_flag=True))
     det_pixels = centred_pixel(det, pixel_range)
     dae = monitor_normalising_dae(
         det_pixels=det_pixels, frames=frames, periods=periods, save_run=save_run, monitor=mon
@@ -255,7 +255,7 @@ def motor_adaptive_scan(  # noqa: PLR0913
         an :obj:`ibex_bluesky_core.callbacks.ISISCallbacks` instance.
 
     """
-    block = BlockMot(prefix=get_pv_prefix(), block_name=block_name)
+    block = BlockRw(float, prefix=get_pv_prefix(), block_name=block_name, write_config=BlockWriteConfig(use_global_moving_flag=True))
     det_pixels = centred_pixel(det, pixel_range)
     dae = monitor_normalising_dae(
         det_pixels=det_pixels, frames=frames, periods=periods, save_run=save_run, monitor=mon

--- a/tests/plans/test_init.py
+++ b/tests/plans/test_init.py
@@ -7,7 +7,7 @@ from ophyd_async.plan_stubs import ensure_connected
 from ophyd_async.sim import SimMotor
 from ophyd_async.testing import callback_on_mock_put, set_mock_value
 
-from ibex_bluesky_core.devices.block import BlockMot, BlockR
+from ibex_bluesky_core.devices.block import BlockMot, BlockR, BlockRw
 from ibex_bluesky_core.devices.simpledae import (
     Controller,
     MonitorNormalizer,
@@ -48,7 +48,7 @@ def test_scan_motor_creates_block_device_and_dae(RE):
         )
         scan.assert_called_once()
         assert isinstance(scan.call_args[1]["dae"], SimpleDae)
-        assert isinstance(scan.call_args[1]["block"], BlockMot)
+        assert isinstance(scan.call_args[1]["block"], BlockRw)
         assert scan.call_args[1]["block"].name == block_name
 
 
@@ -76,7 +76,7 @@ def test_adaptive_scan_motor_creates_block_device_and_dae(RE):
         )
         scan.assert_called_once()
         assert isinstance(scan.call_args[1]["dae"], SimpleDae)
-        assert isinstance(scan.call_args[1]["block"], BlockMot)
+        assert isinstance(scan.call_args[1]["block"], BlockRw)
         assert scan.call_args[1]["block"].name == block_name
 
 

--- a/tests/plans/test_init.py
+++ b/tests/plans/test_init.py
@@ -30,7 +30,7 @@ def test_scan_motor_creates_block_device_and_dae(RE):
     prefix = "UNITTEST:"
     block_name = "some_block"
     with (
-        patch("ibex_bluesky_core.plans.get_pv_prefix", return_value=prefix),
+        patch("ibex_bluesky_core.devices.block.get_pv_prefix", return_value=prefix),
         patch("ibex_bluesky_core.devices.simpledae.get_pv_prefix", return_value=prefix),
         patch("ibex_bluesky_core.plans.scan") as scan,
     ):
@@ -56,7 +56,7 @@ def test_adaptive_scan_motor_creates_block_device_and_dae(RE):
     prefix = "UNITTEST:"
     block_name = "some_block"
     with (
-        patch("ibex_bluesky_core.plans.get_pv_prefix", return_value=prefix),
+        patch("ibex_bluesky_core.devices.block.get_pv_prefix", return_value=prefix),
         patch("ibex_bluesky_core.devices.simpledae.get_pv_prefix", return_value=prefix),
         patch("ibex_bluesky_core.plans.adaptive_scan") as scan,
     ):


### PR DESCRIPTION
This PR makes the motor_scan() and motor_adaptive_scan() consturct a BlockRw using the global moving flag. this change is required as if you try and use motor_scan() over something that is using axis.cmd it doesn't have all of the motor fields and then fails to connect to a load of fields that don't exist. this is what the SANS instruments want to do for most cases, so i think we should cater for it. 