### PR TITLE
remove run decorator from polling plan

### DIFF
--- a/doc/plan_stubs/polling.md
+++ b/doc/plan_stubs/polling.md
@@ -1,0 +1,6 @@
+# Continuous polling
+
+[`polling_plan`](ibex_bluesky_core.plans.polling_plan) - is used for moving a motor and dropping updates from a "readable" if no motor updates are provided. An example of this is a laser reading which updates much more quickly than a motor might register it's moved, so the laser readings are not really useful information.
+
+This in itself doesn't start a bluesky "run" so you will need to use a `run_decorator` on any outer plan which calls this plan stub. 
+

--- a/doc/plans/plans.md
+++ b/doc/plans/plans.md
@@ -40,8 +40,6 @@ These take "devices" so you can pass your own DAE object and a movable/readable 
 
 [`adaptive_scan`](ibex_bluesky_core.plans.adaptive_scan) - this is for an adaptive/relative-adaptive scan.
 
-[`polling_plan`](ibex_bluesky_core.plans.polling_plan) - this is used for moving a motor and dropping updates from a "readable" if no motor updates are provided. An example of this is a laser reading which updates much more quickly than a motor might register it's moved, so the laser readings are not really useful information.
-
 An example of using one of these could be: 
 
 ```python

--- a/src/ibex_bluesky_core/plans/__init__.py
+++ b/src/ibex_bluesky_core/plans/__init__.py
@@ -291,6 +291,9 @@ def polling_plan(
 ) -> Generator[Msg, None, None]:
     """Move to a destination but drop updates from readable if motor position has not changed.
 
+    Note - this does not start a run, this should be done with a run_decorator or similar in an
+    outer plan which calls this plan.
+
     Args:
         motor: the motor to move.
         readable: the readable to read updates from, but drop if motor has not moved.

--- a/src/ibex_bluesky_core/plans/__init__.py
+++ b/src/ibex_bluesky_core/plans/__init__.py
@@ -21,7 +21,14 @@ from ibex_bluesky_core.utils import NamedReadableAndMovable, centred_pixel
 if TYPE_CHECKING:
     from ibex_bluesky_core.devices.simpledae import SimpleDae
 
-__all__ = ["adaptive_scan", "motor_adaptive_scan", "motor_scan", "polling_plan", "scan"]
+__all__ = [
+    "NamedReadableAndMovable",
+    "adaptive_scan",
+    "motor_adaptive_scan",
+    "motor_scan",
+    "polling_plan",
+    "scan",
+]
 
 
 def scan(  # noqa: PLR0913

--- a/src/ibex_bluesky_core/plans/__init__.py
+++ b/src/ibex_bluesky_core/plans/__init__.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any
 import bluesky.plans as bp
 from bluesky import plan_stubs as bps
 from bluesky.plan_stubs import trigger_and_read
-from bluesky.preprocessors import run_decorator
 from bluesky.protocols import NamedMovable, Readable
 from bluesky.utils import Msg
 from ophyd_async.plan_stubs import ensure_connected

--- a/src/ibex_bluesky_core/plans/__init__.py
+++ b/src/ibex_bluesky_core/plans/__init__.py
@@ -5,8 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 import bluesky.plans as bp
 from bluesky import plan_stubs as bps
-from bluesky.plan_stubs import trigger_and_read
-from bluesky.protocols import NamedMovable, Readable
+from bluesky.protocols import NamedMovable
 from bluesky.utils import Msg
 from ophyd_async.plan_stubs import ensure_connected
 
@@ -14,7 +13,8 @@ from ibex_bluesky_core.callbacks import ISISCallbacks
 from ibex_bluesky_core.devices.block import BlockWriteConfig, block_rw
 from ibex_bluesky_core.devices.simpledae import monitor_normalising_dae
 from ibex_bluesky_core.fitting import FitMethod
-from ibex_bluesky_core.utils import NamedReadableAndMovable, centred_pixel
+from ibex_bluesky_core.plan_stubs import polling_plan
+from ibex_bluesky_core.utils import centred_pixel
 
 if TYPE_CHECKING:
     from ibex_bluesky_core.devices.simpledae import SimpleDae
@@ -284,47 +284,3 @@ def motor_adaptive_scan(  # noqa: PLR0913
             rel=rel,
         )
     )
-
-
-def polling_plan(
-    motor: NamedReadableAndMovable, readable: Readable[Any], destination: float
-) -> Generator[Msg, None, None]:
-    """Move to a destination but drop updates from readable if motor position has not changed.
-
-    Note - this does not start a run, this should be done with a run_decorator or similar in an
-    outer plan which calls this plan.
-
-    Args:
-        motor: the motor to move.
-        readable: the readable to read updates from, but drop if motor has not moved.
-        destination: the destination position.
-
-    Returns:
-        None
-
-    If we just used bp.scan() with a readable that updates more frequently than a motor can
-    register that it has moved, we would have lots of updates with the same motor position,
-    which may not be helpful.
-
-    """
-    yield from bps.checkpoint()
-    yield from bps.create()
-    reading = yield from bps.read(motor)
-    yield from bps.read(readable)
-    yield from bps.save()
-
-    # start the ramp
-    status = yield from bps.abs_set(motor, destination, wait=False)
-    while not status.done:
-        yield from bps.create()
-        new_reading = yield from bps.read(motor)
-        yield from bps.read(readable)
-
-        if new_reading[motor.name]["value"] == reading[motor.name]["value"]:
-            yield from bps.drop()
-        else:
-            reading = new_reading
-            yield from bps.save()
-
-    # take a 'post' data point
-    yield from trigger_and_read([motor, readable])

--- a/src/ibex_bluesky_core/plans/__init__.py
+++ b/src/ibex_bluesky_core/plans/__init__.py
@@ -287,7 +287,6 @@ def motor_adaptive_scan(  # noqa: PLR0913
     )
 
 
-@run_decorator(md={})
 def polling_plan(
     motor: NamedReadableAndMovable, readable: Readable[Any], destination: float
 ) -> Generator[Msg, None, None]:

--- a/tests/plans/test_init.py
+++ b/tests/plans/test_init.py
@@ -1,8 +1,8 @@
 # pyright: reportMissingParameterType=false
-
 from unittest.mock import patch
 
 import pytest
+from bluesky.preprocessors import run_decorator
 from ophyd_async.plan_stubs import ensure_connected
 from ophyd_async.sim import SimMotor
 from ophyd_async.testing import callback_on_mock_put, set_mock_value
@@ -289,8 +289,14 @@ async def test_polling_plan_drops_readable_updates_if_no_new_motor_position(RE):
     callback_on_mock_put(motor.user_readback, lots_of_updates_between_set)
     captured_events = []
 
+    @run_decorator(md={})
+    def p():
+        return (
+            yield from polling_plan(motor=motor, readable=block_readable, destination=destination)
+        )  # pyright: ignore[reportArgumentType])
+
     RE(
-        polling_plan(motor=motor, readable=block_readable, destination=destination),  # pyright: ignore[reportArgumentType]
+        p(),
         {"event": lambda x, y: captured_events.append(y["data"])},
     )
 

--- a/tests/plans/test_init.py
+++ b/tests/plans/test_init.py
@@ -17,11 +17,11 @@ from ibex_bluesky_core.devices.simpledae import (
     Waiter,
 )
 from ibex_bluesky_core.fitting import Gaussian
+from ibex_bluesky_core.plan_stubs import polling_plan
 from ibex_bluesky_core.plans import (
     adaptive_scan,
     motor_adaptive_scan,
     motor_scan,
-    polling_plan,
     scan,
 )
 


### PR DESCRIPTION
this moves polling_plan (annoyingly named _plan!) to plan_stubs, but keeps in the __all__ of plans for backwards compatibility on LOQ. 