### PR TITLE
Ticket195

### DIFF
--- a/doc/callbacks/file_writing.md
+++ b/doc/callbacks/file_writing.md
@@ -49,7 +49,7 @@ of the scan, in `C:\instrument\var\logs\bluesky\output_files\`.
 
 Optional parameters, not shown above, include:
 - `output_dir` parameter is optional, if not input the file will by default be placed in 
-`\\isis\inst$\ndx<inst>\user\TEST\scans\<rbnumber>`. 
+`\\isis\inst$\ndx<inst>\user\bluesky_scans\<rbnumber>`. 
 - `postfix` an optional suffix to append to the end of the file name, to disambiguate scans. Default is no suffix.
 
 The data is prepended on the first event with the names and units of each logged field, and then subsequently the data 

--- a/doc/dev/troubleshooting.md
+++ b/doc/dev/troubleshooting.md
@@ -43,7 +43,7 @@ showing how to do this.
 
 ### Scientist-facing data
 
-Scientist-facing output files are written to `<isis share>\inst$\NDX<inst>\user\test\scans\<current rb number>` by 
+Scientist-facing output files are written to `<isis share>\inst$\NDX<inst>\user\bluesky_scans\<current rb number>` by 
 default.
 
 Custom file-output paths can be specified by passing extra arguments to 

--- a/src/ibex_bluesky_core/callbacks/_fitting.py
+++ b/src/ibex_bluesky_core/callbacks/_fitting.py
@@ -149,7 +149,7 @@ class LiveFitLogger(CallbackBase):
 
         self.livefit = livefit
         self.postfix = postfix
-        self.output_dir = Path(output_dir or get_default_output_path() / "fitting")
+        self.output_dir = Path(output_dir or get_default_output_path())
         self.current_start_document: str | None = None
 
         self.x = x

--- a/src/ibex_bluesky_core/callbacks/_utils.py
+++ b/src/ibex_bluesky_core/callbacks/_utils.py
@@ -27,7 +27,7 @@ def get_instrument() -> str:
 def get_default_output_path() -> Path:
     output_dir_env = os.environ.get(OUTPUT_DIR_ENV_VAR)
     return (
-        Path("//isis.cclrc.ac.uk/inst$") / node() / "user" / "bluesky_scans" / RB
+        Path("//isis.cclrc.ac.uk/inst$") / node() / "user" / "bluesky_scans"
         if output_dir_env is None
         else Path(output_dir_env)
     )

--- a/src/ibex_bluesky_core/callbacks/_utils.py
+++ b/src/ibex_bluesky_core/callbacks/_utils.py
@@ -27,7 +27,7 @@ def get_instrument() -> str:
 def get_default_output_path() -> Path:
     output_dir_env = os.environ.get(OUTPUT_DIR_ENV_VAR)
     return (
-        Path("//isis.cclrc.ac.uk/inst$") / node() / "user" / "TEST" / "scans"
+        Path("//isis.cclrc.ac.uk/inst$") / node() / "user" / "bluesky_scans" / RB
         if output_dir_env is None
         else Path(output_dir_env)
     )


### PR DESCRIPTION
### Description of work

updated the file path for the default location, with a flat structure.

### Ticket

[*Link to Ticket*](https://github.com/ISISComputingGroup/ibex_bluesky_core/issues/195)

### Labels

*Add appropriate label(s) to this PR*

 - 'bluesky-Semver-Major' - Breaking Change
 - 'bluesky-Semver-Minor' - New feature
 - 'bluesky-bug' - Bug fix
 - 'bluesky-documentation' - Document Changes
 - 'bluesky-ignore-for-release' - Do not show in the release notes 

 **Labels can be found of the right-hand sidebar of this PR once created**
 
 ### Acceptance criteria
 
 I forgot to add a way to test this, but it can be tricky as your test machine won't be found on \\isis\inst$\ 
 
 How I tested the concept of the filepath changes:
 
 1. After switching to this branch, change the `_ulits.py` file path to a local folder of your choosing.
 2. Set up the bluesky local development, instructions to which can be found [here](https://isiscomputinggroup.github.io/ibex_bluesky_core/dev/set_up_dev_environment.html).
 3. Within your Python venv, set up the following [enviroment variables](https://isiscomputinggroup.github.io/ibex_bluesky_core/dev/manual_system_testing.html#manual-system-testing).
 4. The test used within the example was:
 
     `python c:\instrument\dev\ibex_bluesky_core\manual_system_tests\dae_scan.py` 
 
     Open this file, and comment out both the `human_readable_file_output_dir` and `live_fit_logger_output_dir` filepath
5. After this has successful run, the folder location you selected should now be populated with a folder of a RB number, most likely '0', in which two .txt files should exist.
 
 
 
 
