### PR TITLE
raise exception if not in manager mode

### DIFF
--- a/src/ibex_bluesky_core/devices/__init__.py
+++ b/src/ibex_bluesky_core/devices/__init__.py
@@ -6,7 +6,7 @@ import binascii
 import zlib
 from typing import TypeVar
 
-from ophyd_async.core import SignalDatatype, SignalRW
+from ophyd_async.core import SignalDatatype, SignalRW, StrictEnum
 from ophyd_async.epics.core import epics_signal_rw
 
 T = TypeVar("T", bound=SignalDatatype)
@@ -43,3 +43,10 @@ def isis_epics_signal_rw(datatype: type[T], read_pv: str, name: str = "") -> Sig
     """Make a RW signal with ISIS' PV naming standard ie. read_pv as TITLE, write_pv as TITLE:SP."""
     write_pv = f"{read_pv}:SP"
     return epics_signal_rw(datatype, read_pv, write_pv, name)
+
+
+class NoYesChoice(StrictEnum):
+    """No-Yes enum for an mbbi/mbbo or bi/bo with capitalised "No" and "Yes" options."""
+
+    NO = "No"
+    YES = "Yes"

--- a/src/ibex_bluesky_core/devices/__init__.py
+++ b/src/ibex_bluesky_core/devices/__init__.py
@@ -11,7 +11,7 @@ from ophyd_async.epics.core import epics_signal_rw
 
 T = TypeVar("T", bound=SignalDatatype)
 
-__all__ = ["compress_and_hex", "dehex_and_decompress", "isis_epics_signal_rw"]
+__all__ = ["NoYesChoice", "compress_and_hex", "dehex_and_decompress", "isis_epics_signal_rw"]
 
 
 def dehex_and_decompress(value: bytes) -> bytes:

--- a/tests/test_plan_stubs.py
+++ b/tests/test_plan_stubs.py
@@ -153,7 +153,7 @@ def test_redefine_motor(RE):
 async def test_redefine_refl_parameter(RE):
     param = ReflParameter(prefix="", name="some_refl_parameter", changing_timeout_s=60)
     await param.connect(mock=True)
-    set_mock_value(param.redefine.manager_mode, NoYesChoice.YES)
+    set_mock_value(param.redefine.manager_mode, NoYesChoice.YES)  # pyright: ignore [reportOptionalMemberAccess]
 
     RE(redefine_refl_parameter(param, 42.0))
 

--- a/tests/test_plan_stubs.py
+++ b/tests/test_plan_stubs.py
@@ -8,8 +8,9 @@ import pytest
 from bluesky.utils import Msg
 from ophyd_async.epics.motor import UseSetMode
 from ophyd_async.plan_stubs import ensure_connected
-from ophyd_async.testing import get_mock_put
+from ophyd_async.testing import get_mock_put, set_mock_value
 
+from ibex_bluesky_core.devices import NoYesChoice
 from ibex_bluesky_core.devices.block import BlockMot
 from ibex_bluesky_core.devices.reflectometry import ReflParameter
 from ibex_bluesky_core.plan_stubs import (
@@ -152,6 +153,7 @@ def test_redefine_motor(RE):
 async def test_redefine_refl_parameter(RE):
     param = ReflParameter(prefix="", name="some_refl_parameter", changing_timeout_s=60)
     await param.connect(mock=True)
+    set_mock_value(param.redefine.manager_mode, NoYesChoice.YES)
 
     RE(redefine_refl_parameter(param, 42.0))
 


### PR DESCRIPTION
### Description of work

This adds an exception for when trying to redefine a reflectometry parameter if the instrument is not in manager mode. 

As our plans/plan stubs don't do any redefining in this library other than redefine_refl_param() which will feed-through the exception I think this is all we need to do - IMO it should actually halt a plan and therefore the exception doesn't need to be caught on the top-level plan. This should mean it's a bit more readable to the user that their redefine has failed.

### Ticket

Closes #146  and probably #189 

### Labels

*Add appropriate label(s) to this PR*

 - 'bluesky-Semver-Major' - Breaking Change
 - 'bluesky-Semver-Minor' - New feature
 - 'bluesky-bug' - Bug fix
 - 'bluesky-documentation' - Document Changes
 - 'bluesky-ignore-for-release' - Do not show in the release notes 

 **Labels can be found of the right-hand sidebar of this PR once created**

### Acceptance criteria

If not in manager mode, a nicer error is displayed. If in manager mode, redefines still work. 

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*
