### PR TITLE
Fix erroneous ufloat warning during fitting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,10 @@ dependencies = [
   "scippneutron",  # neutron-specific utilities for scipp
   "typing-extensions",  # TypeVar with default-arg support
   "tzdata",  # Windows timezone support
+
+  # Transitive dependency of lmfit, but we want to pin this to avoid https://github.com/lmfit/lmfit-py/issues/999
+  # Remove this dependency here once lmfit >= 1.3.4 is released.
+  "uncertainties<3.2.3",
 ]
 
 [project.optional-dependencies]
@@ -83,6 +87,7 @@ asyncio_mode = "auto"
 addopts = "--cov --cov-report=html -vv"
 filterwarnings = [
     'ignore:FigureCanvasAgg is non-interactive, and thus cannot be shown:UserWarning',
+    'error:Using UFloat objects with std_dev==0 may give unexpected results.:UserWarning',
 ]
 
 [tool.pytest_env]


### PR DESCRIPTION
### Description of work

Fix a warning of the form:

```
Using UFloat objects with std_dev==0 may give unexpected results.
```
during fitting. This is caused by https://github.com/lmfit/lmfit-py/issues/999 .

### Ticket

n/a

### Labels

*Add appropriate label(s) to this PR*

 - 'bluesky-Semver-Major' - Breaking Change
 - 'bluesky-Semver-Minor' - New feature
 - 'bluesky-bug' - Bug fix
 - 'bluesky-documentation' - Document Changes
 - 'bluesky-ignore-for-release' - Do not show in the release notes 

 **Labels can be found of the right-hand sidebar of this PR once created**

### Acceptance criteria

- [ ] Pull request title is understandable for a user (e.g. scientist) reading the release notes. The PR title should be a short description of the change from a user perspective.
- [ ] Pull request has appropriate labels for automatic release-notes generation
- [ ] Warning no longer appears

### Documentation
n/a
