### PR TITLE
Enforce adding release-note labels to PRs

### DIFF
--- a/.github/workflows/check_pr_has_label.yml
+++ b/.github/workflows/check_pr_has_label.yml
@@ -1,0 +1,24 @@
+name: Check PR has release labels
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+
+jobs:
+  has_label:
+    name: Check PR has release labels
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "PR does not have a release label."
+          exit 1
+        if: |
+          !contains(github.event.pull_request.labels.*.name, 'bluesky-bug') &&
+          !contains(github.event.pull_request.labels.*.name, 'bluesky-Semver-Major') &&
+          !contains(github.event.pull_request.labels.*.name, 'bluesky-Semver-Minor') &&
+          !contains(github.event.pull_request.labels.*.name, 'bluesky-documentation') &&
+          !contains(github.event.pull_request.labels.*.name, 'bluesky-ignore-for-release')


### PR DESCRIPTION
### Description of work

Add a check to ensure PRs can't be merged without a release label.

### Ticket

None

### Labels

*Add appropriate label(s) to this PR*

 - 'bluesky-Semver-Major' - Breaking Change
 - 'bluesky-Semver-Minor' - New feature
 - 'bluesky-bug' - Bug fix
 - 'bluesky-documentation' - Document Changes
 - 'bluesky-ignore-for-release' - Do not show in the release notes 

bit meta ;)

### Acceptance criteria

- [ ] Pull request title is understandable for a user (e.g. scientist) reading the release notes. The PR title should be a short description of the change from a user perspective.
- [ ] Pull request has appropriate labels for automatic release-notes generation
- [ ] Check fails if no appropriate release-notes labels on the PR
- [ ] Check passes if a release note label is on the PR

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*
