### PR TITLE
fix manual system test

### DIFF
--- a/manual_system_tests/dae_scan.py
+++ b/manual_system_tests/dae_scan.py
@@ -75,7 +75,7 @@ def dae_scan_plan() -> Generator[Msg, None, None]:
             controller.run_number.name,
             reducer.det_counts.name,
             reducer.det_counts_stddev.name,
-            dae.good_frames.name,
+            dae.period.good_frames.name,
         ],
         human_readable_file_output_dir=Path("C:\\")
         / "instrument"


### PR DESCRIPTION
### Description of work

This now uses a `PeriodGoodFramesWaiter` which adds `dae.period.good_frames` instead of `dae.good_frames`. 


### Ticket

None, found during manual system tests for IBEX release 25.8.0


### Labels

*Add appropriate label(s) to this PR*

 - 'bluesky-Semver-Major' - Breaking Change
 - 'bluesky-Semver-Minor' - New feature
 - 'bluesky-bug' - Bug fix
 - 'bluesky-documentation' - Document Changes
 - 'bluesky-ignore-for-release' - Do not show in the release notes 

 **Labels can be found of the right-hand sidebar of this PR once created**

### Acceptance criteria

- [ ] Pull request title is understandable for a user (e.g. scientist) reading the release notes. The PR title should be a short description of the change from a user perspective.
- [ ] Pull request has appropriate labels for automatic release-notes generation

*List the acceptance criteria for the PR. The aim is provide information to help the reviewer*

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*
