### PR TITLE
Motor limits are now checked by `ophyd-async`

### DIFF
--- a/doc/devices/blocks.md
+++ b/doc/devices/blocks.md
@@ -118,7 +118,9 @@ type `float`, and as such does not take a type argument (unlike the other block 
 
 `Checkable` means that moves which would eventually violate limits can be detected by
 bluesky simulators, before the plan ever runs. This can help to catch errors before
-the plan is executed against hardware.
+the plan is executed against hardware. There is also limit-checking at runtime;
+a {external+ophyd_async:py:obj}`MotorLimitsException <ophyd_async.epics.motor.MotorLimitsException>` will be raised
+at runtime if a requested position is outside the motor's limits.
 
 `Stoppable` means that the motor can be asked to stop by bluesky. Plans may choose to execute
 a `stop()` on failure, or explicitly during a plan.

--- a/src/ibex_bluesky_core/devices/block.py
+++ b/src/ibex_bluesky_core/devices/block.py
@@ -407,6 +407,10 @@ class BlockMot(Motor, Movable[float], HasName):
         """Pass through set to superclass.
 
         This is needed so that type-checker correctly understands the type of set.
+
+        This method will raise
+        :external+ophyd_async:py:obj:`ophyd_async.epics.motor.MotorLimitsException`
+        if the requested position was outside the motor's limits.
         """
         return super().set(value, timeout)
 

--- a/tests/devices/test_block.py
+++ b/tests/devices/test_block.py
@@ -6,6 +6,7 @@ from unittest.mock import ANY, MagicMock, call, patch
 
 import bluesky.plan_stubs as bps
 import bluesky.plans as bp
+import ophyd_async
 import pytest
 from ophyd_async.testing import get_mock_put, set_mock_value
 
@@ -349,11 +350,29 @@ def test_block_reprs():
     assert repr(BlockMot(block_name="qux", prefix="")) == "BlockMot(name=qux)"
 
 
-async def test_block_mot_set(mot_block):
+async def test_block_mot_set_within_limits(mot_block):
     set_mock_value(mot_block.user_setpoint, 10)
     set_mock_value(mot_block.velocity, 10)
+    set_mock_value(mot_block.high_limit_travel, 1000)
+    set_mock_value(mot_block.low_limit_travel, -1000)
     await mot_block.set(20)
     get_mock_put(mot_block.user_setpoint).assert_called_once_with(20, wait=True)
+
+
+@pytest.mark.skipif(
+    ophyd_async._version.version_tuple < (0, 13, 2),
+    reason="Exception only raised in ophyd_async >= 0.13.2",
+)
+async def test_block_mot_set_outside_limits(mot_block):
+    # Local import as API not available in older ophyd_async versions
+    from ophyd_async.epics.motor import MotorLimitsException  # noqa PLC0415
+
+    set_mock_value(mot_block.user_setpoint, 10)
+    set_mock_value(mot_block.velocity, 10)
+    set_mock_value(mot_block.high_limit_travel, 15)
+    set_mock_value(mot_block.low_limit_travel, 5)
+    with pytest.raises(MotorLimitsException):
+        await mot_block.set(20)
 
 
 @pytest.mark.parametrize("timeout_is_error", [True, False])


### PR DESCRIPTION
### Description of work

Fixes the future-dependencies build. Upstream ophyd-async has added motor-limits checking (in https://github.com/bluesky/ophyd-async/pull/1032).

### Ticket

n/a

### Labels

*Add appropriate label(s) to this PR*

 - 'bluesky-Semver-Major' - Breaking Change
 - 'bluesky-Semver-Minor' - New feature
 - 'bluesky-bug' - Bug fix
 - 'bluesky-documentation' - Document Changes
 - 'bluesky-ignore-for-release' - Do not show in the release notes 

 **Labels can be found of the right-hand sidebar of this PR once created**

### Acceptance criteria

- [ ] Pull request title is understandable for a user (e.g. scientist) reading the release notes. The PR title should be a short description of the change from a user perspective.
- [ ] Pull request has appropriate labels for automatic release-notes generation

*List the acceptance criteria for the PR. The aim is provide information to help the reviewer*

### Documentation

Docs added to highlight to users that motor limits will be checked for a `BlockMot`.
