### PR TITLE
Fix pyright developer checks

### DIFF
--- a/src/ibex_bluesky_core/devices/reflectometry.py
+++ b/src/ibex_bluesky_core/devices/reflectometry.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import typing
 
 import numpy as np
 import numpy.typing as npt
@@ -285,4 +286,4 @@ class AngleMappingReducer(Reducer, StandardReadable):
         self._background_setter(result.params["background"].value)
         self._background_err_setter(result.params["background"].stderr)
 
-        self._r_squared_setter(result.rsquared)
+        self._r_squared_setter(typing.cast(float, result.rsquared))

--- a/src/ibex_bluesky_core/devices/simpledae/_reducers.py
+++ b/src/ibex_bluesky_core/devices/simpledae/_reducers.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import math
+import typing
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable, Collection, Sequence
 
@@ -449,8 +450,8 @@ class PeriodSpecIntegralsReducer(Reducer, StandardReadable):
         self._det_integrals_setter(det_integrals)
         self._mon_integrals_setter(mon_integrals)
 
-        scalar_det_sum = det_integrals.sum()
-        scalar_mon_sum = mon_integrals.sum()
+        scalar_det_sum = typing.cast(int, det_integrals.sum())
+        scalar_mon_sum = typing.cast(int, mon_integrals.sum())
         self._det_sum_setter(scalar_det_sum)
         self._mon_sum_setter(scalar_mon_sum)
 


### PR DESCRIPTION
### Description of work

Fix pyright developer checks.

Pyright became a little stricter on the difference between `float` and `np.float32`, and similarly for ints. `ophyd-async` needs the python types (not numpy types) as type-hints.

### Acceptance criteria

- [ ] Pull request title is understandable for a user (e.g. scientist) reading the release notes. The PR title should be a short description of the change from a user perspective.
- [ ] Pull request has appropriate labels for automatic release-notes generation
